### PR TITLE
Fix translation logging and allow extra params

### DIFF
--- a/Tabular_to_Neo4j/nodes/header_processing/header_translation.py
+++ b/Tabular_to_Neo4j/nodes/header_processing/header_translation.py
@@ -59,7 +59,11 @@ def translate_header_llm_node(state: GraphState, config: RunnableConfig) -> Grap
         
         # Call the LLM to translate headers
         logger.debug("Calling LLM for header translation")
-        response = call_llm_with_json_output(prompt, state_name="translate_header")
+        response = call_llm_with_json_output(
+            prompt,
+            state_name="translate_header",
+            is_translation=True,
+        )
         
         # Extract the translated headers
         translated_header = response
@@ -78,7 +82,9 @@ def translate_header_llm_node(state: GraphState, config: RunnableConfig) -> Grap
             return state
         
         # Update the state with the translated headers
-        logger.info(f"Successfully translated headers from {source_language} to {TARGET_HEADER_LANGUAGE}")
+        logger.info(
+            f"Successfully translated headers from {header_language} to {metadata_language}"
+        )
         logger.debug(f"Original headers: {header}")
         logger.debug(f"Translated headers: {translated_header}")
         

--- a/Tabular_to_Neo4j/utils/llm_manager.py
+++ b/Tabular_to_Neo4j/utils/llm_manager.py
@@ -791,13 +791,18 @@ def save_prompt_sample(template_name: str, formatted_prompt: str, kwargs: dict, 
         print(f"Error updating metadata: {e}")
         pass
 
-def call_llm_with_json_output(prompt: str, state_name: str = None) -> Dict[str, Any]:
+def call_llm_with_json_output(
+    prompt: str,
+    state_name: str = None,
+    **kwargs,
+) -> Dict[str, Any]:
     """
     Call the LLM and parse the response as JSON.
     
     Args:
         prompt: The prompt to send to the LLM
         state_name: The name of the state to use the LLM for
+        **kwargs: Optional parameters for future extensions
         
     Returns:
         The parsed JSON response as a dictionary


### PR DESCRIPTION
## Summary
- clean up header translation node logging
- forward `is_translation` flag to LLM call
- allow optional kwargs in `call_llm_with_json_output`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError for 'langchain_core' and 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68471fe1f4fc832fbe669b7edff5ab8f