### PR TITLE
Encapsulate state with dataclass

### DIFF
--- a/Tabular_to_Neo4j/tests/conftest.py
+++ b/Tabular_to_Neo4j/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Dict, Any
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 
+
 @pytest.fixture
 def sample_csv_path():
     """Fixture that returns a path to a sample CSV file for testing."""
@@ -16,11 +17,13 @@ def sample_csv_path():
     tests_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(tests_dir, "test_data", "sample.csv")
 
+
 @pytest.fixture
 def ensure_test_data_dir(sample_csv_path):
     """Ensure the test data directory exists."""
     os.makedirs(os.path.dirname(sample_csv_path), exist_ok=True)
     return os.path.dirname(sample_csv_path)
+
 
 @pytest.fixture
 def sample_csv_content(ensure_test_data_dir, sample_csv_path):
@@ -32,65 +35,90 @@ def sample_csv_content(ensure_test_data_dir, sample_csv_path):
 4,Alice Brown,35,alice@example.com,Houston
 5,Charlie Wilson,28,charlie@example.com,Phoenix
 """
-    with open(sample_csv_path, 'w') as f:
+    with open(sample_csv_path, "w") as f:
         f.write(content)
     return sample_csv_path
+
 
 @pytest.fixture
 def sample_dataframe():
     """Fixture that returns a sample pandas DataFrame for testing."""
-    return pd.DataFrame({
-        'id': [1, 2, 3, 4, 5],
-        'name': ['John Doe', 'Jane Smith', 'Bob Johnson', 'Alice Brown', 'Charlie Wilson'],
-        'age': [30, 25, 40, 35, 28],
-        'email': ['john@example.com', 'jane@example.com', 'bob@example.com', 
-                 'alice@example.com', 'charlie@example.com'],
-        'city': ['New York', 'Los Angeles', 'Chicago', 'Houston', 'Phoenix']
-    })
+    return pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": [
+                "John Doe",
+                "Jane Smith",
+                "Bob Johnson",
+                "Alice Brown",
+                "Charlie Wilson",
+            ],
+            "age": [30, 25, 40, 35, 28],
+            "email": [
+                "john@example.com",
+                "jane@example.com",
+                "bob@example.com",
+                "alice@example.com",
+                "charlie@example.com",
+            ],
+            "city": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"],
+        }
+    )
+
 
 @pytest.fixture
 def sample_graph_state(sample_dataframe, sample_csv_path):
     """Fixture that returns a sample GraphState for testing."""
-    return GraphState({
-        'csv_file_path': sample_csv_path,
-        'raw_dataframe': sample_dataframe.copy(),
-        'processed_dataframe': sample_dataframe.copy(),
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'error_messages': []
-    })
+    return GraphState.from_dict(
+        {
+            "csv_file_path": sample_csv_path,
+            "raw_dataframe": sample_dataframe.copy(),
+            "processed_dataframe": sample_dataframe.copy(),
+            "has_header": True,
+            "detected_header": ["id", "name", "age", "email", "city"],
+            "final_header": ["id", "name", "age", "email", "city"],
+            "error_messages": [],
+        }
+    )
+
 
 @pytest.fixture
 def runnable_config():
     """Fixture that returns a sample RunnableConfig for testing."""
-    return RunnableConfig({
-        'configurable': {
-            'thread_id': 'test-thread'
-        }
-    })
+    return RunnableConfig({"configurable": {"thread_id": "test-thread"}})
+
 
 @pytest.fixture
 def mock_llm_response():
     """Fixture that provides mock LLM responses for different state names."""
+
     def _get_response(state_name: str) -> Dict[str, Any]:
         responses = {
             "infer_header": {
                 "inferred_headers": ["id", "name", "age", "email", "city"],
-                "confidence": "high"
+                "confidence": "high",
             },
             "validate_header": {
                 "validated_headers": ["id", "name", "age", "email", "city"],
                 "suggestions": [],
-                "is_valid": True
+                "is_valid": True,
             },
             "analyze_column_semantics": {
                 "column_semantics": {
-                    "id": {"type": "identifier", "description": "Unique identifier for the person"},
-                    "name": {"type": "personal_name", "description": "Full name of the person"},
+                    "id": {
+                        "type": "identifier",
+                        "description": "Unique identifier for the person",
+                    },
+                    "name": {
+                        "type": "personal_name",
+                        "description": "Full name of the person",
+                    },
                     "age": {"type": "numeric_age", "description": "Age in years"},
-                    "email": {"type": "email_address", "description": "Contact email address"},
-                    "city": {"type": "location", "description": "City of residence"}
+                    "email": {
+                        "type": "email_address",
+                        "description": "Contact email address",
+                    },
+                    "city": {"type": "location", "description": "City of residence"},
                 }
             },
             "classify_entities_properties": {
@@ -101,8 +129,8 @@ def mock_llm_response():
                     "name": "property",
                     "age": "property",
                     "email": "property",
-                    "city": "property"
-                }
+                    "city": "property",
+                },
             },
             "reconcile_entity_property": {
                 "consensus_classification": {
@@ -112,8 +140,8 @@ def mock_llm_response():
                         "name": "property",
                         "age": "property",
                         "email": "property",
-                        "city": "property"
-                    }
+                        "city": "property",
+                    },
                 }
             },
             "map_properties_to_entity": {
@@ -125,19 +153,17 @@ def mock_llm_response():
                     "name": "String",
                     "age": "Integer",
                     "email": "String",
-                    "city": "String"
-                }
+                    "city": "String",
+                },
             },
-            "infer_entity_relationships": {
-                "entity_relationships": []
-            },
+            "infer_entity_relationships": {"entity_relationships": []},
             "generate_cypher_templates": {
                 "cypher_templates": [
                     "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
                 ],
                 "constraints_and_indexes": [
                     "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
-                ]
+                ],
             },
             "synthesize_final_schema": {
                 "final_schema": {
@@ -146,8 +172,12 @@ def mock_llm_response():
                         "id": {"entity": "Person", "type": "String", "is_key": True},
                         "name": {"entity": "Person", "type": "String", "is_key": False},
                         "age": {"entity": "Person", "type": "Integer", "is_key": False},
-                        "email": {"entity": "Person", "type": "String", "is_key": False},
-                        "city": {"entity": "Person", "type": "String", "is_key": False}
+                        "email": {
+                            "entity": "Person",
+                            "type": "String",
+                            "is_key": False,
+                        },
+                        "city": {"entity": "Person", "type": "String", "is_key": False},
                     },
                     "relationships": [],
                     "cypher_templates": [
@@ -155,10 +185,10 @@ def mock_llm_response():
                     ],
                     "constraints_and_indexes": [
                         "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
-                    ]
+                    ],
                 }
-            }
+            },
         }
         return responses.get(state_name, {})
-    
+
     return _get_response

--- a/Tabular_to_Neo4j/tests/nodes/analysis/test_column_analytics.py
+++ b/Tabular_to_Neo4j/tests/nodes/analysis/test_column_analytics.py
@@ -4,102 +4,103 @@ Tests for the column analytics node.
 
 import pytest
 import pandas as pd
-from Tabular_to_Neo4j.nodes.analysis.column_analytics import perform_column_analytics_node
+from Tabular_to_Neo4j.nodes.analysis.column_analytics import (
+    perform_column_analytics_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_missing_dataframe(runnable_config):
     """Test that the perform_column_analytics_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'column_analytics' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot analyze columns" in result_state['error_messages'][0]
+    assert "column_analytics" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot analyze columns" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_success(sample_dataframe, runnable_config):
     """Test that the perform_column_analytics_node successfully analyzes columns."""
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check that the column analytics were added to the state
-    assert 'column_analytics' in result_state
-    assert isinstance(result_state['column_analytics'], dict)
-    assert len(result_state['column_analytics']) == len(sample_dataframe.columns)
-    assert result_state['error_messages'] == []
-    
+    assert "column_analytics" in result_state
+    assert isinstance(result_state["column_analytics"], dict)
+    assert len(result_state["column_analytics"]) == len(sample_dataframe.columns)
+    assert result_state["error_messages"] == []
+
     # Check that each column has the expected analytics based on the actual implementation
     for column in sample_dataframe.columns:
-        assert column in result_state['column_analytics']
-        column_stats = result_state['column_analytics'][column]
-        assert 'data_type' in column_stats
-        assert 'uniqueness_ratio' in column_stats  # The actual field name in the implementation
-        assert 'cardinality' in column_stats
-        assert 'patterns' in column_stats
-        assert 'sample_values' in column_stats
-        assert 'missing_percentage' in column_stats
+        assert column in result_state["column_analytics"]
+        column_stats = result_state["column_analytics"][column]
+        assert "data_type" in column_stats
+        assert (
+            "uniqueness_ratio" in column_stats
+        )  # The actual field name in the implementation
+        assert "cardinality" in column_stats
+        assert "patterns" in column_stats
+        assert "sample_values" in column_stats
+        assert "missing_percentage" in column_stats
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_numeric_column(runnable_config):
     """Test that the perform_column_analytics_node correctly analyzes numeric columns."""
     # Create a DataFrame with a numeric column
-    df = pd.DataFrame({
-        'numeric_column': [1, 2, 3, 4, 5, 5, 4, 3, 2, 1]
-    })
-    
+    df = pd.DataFrame({"numeric_column": [1, 2, 3, 4, 5, 5, 4, 3, 2, 1]})
+
     # Create initial state
-    initial_state = GraphState({
-        'processed_dataframe': df,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": df, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check the analytics for the numeric column based on the actual implementation
-    column_stats = result_state['column_analytics']['numeric_column']
-    assert column_stats['data_type'] == 'numeric'
-    assert column_stats['uniqueness_ratio'] == 0.5  # 5 unique values out of 10
-    assert column_stats['cardinality'] == 5  # 5 unique values
-    assert 'patterns' in column_stats
-    assert 'sample_values' in column_stats
-    assert 'missing_percentage' in column_stats
+    column_stats = result_state["column_analytics"]["numeric_column"]
+    assert column_stats["data_type"] == "numeric"
+    assert column_stats["uniqueness_ratio"] == 0.5  # 5 unique values out of 10
+    assert column_stats["cardinality"] == 5  # 5 unique values
+    assert "patterns" in column_stats
+    assert "sample_values" in column_stats
+    assert "missing_percentage" in column_stats
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_text_column(runnable_config):
     """Test that the perform_column_analytics_node correctly analyzes text columns."""
     # Create a DataFrame with a text column
-    df = pd.DataFrame({
-        'text_column': ['apple', 'banana', 'apple', 'cherry', 'banana']
-    })
-    
+    df = pd.DataFrame({"text_column": ["apple", "banana", "apple", "cherry", "banana"]})
+
     # Create initial state
-    initial_state = GraphState({
-        'processed_dataframe': df,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": df, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check the analytics for the text column based on the actual implementation
-    column_stats = result_state['column_analytics']['text_column']
-    assert column_stats['data_type'] == 'string'  # The actual data type used in the implementation
-    assert column_stats['uniqueness_ratio'] == 0.6  # 3 unique values out of 5
-    assert column_stats['cardinality'] == 3  # 3 unique values
-    assert 'patterns' in column_stats
-    assert 'sample_values' in column_stats
-    assert 'missing_percentage' in column_stats
+    column_stats = result_state["column_analytics"]["text_column"]
+    assert (
+        column_stats["data_type"] == "string"
+    )  # The actual data type used in the implementation
+    assert column_stats["uniqueness_ratio"] == 0.6  # 3 unique values out of 5
+    assert column_stats["cardinality"] == 3  # 3 unique values
+    assert "patterns" in column_stats
+    assert "sample_values" in column_stats
+    assert "missing_percentage" in column_stats

--- a/Tabular_to_Neo4j/tests/nodes/analysis/test_semantic_analysis.py
+++ b/Tabular_to_Neo4j/tests/nodes/analysis/test_semantic_analysis.py
@@ -4,131 +4,218 @@ Tests for the semantic analysis node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.analysis.semantic_analysis import llm_semantic_column_analysis_node
+from Tabular_to_Neo4j.nodes.analysis.semantic_analysis import (
+    llm_semantic_column_analysis_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_llm_semantic_column_analysis_node_missing_data(runnable_config):
     """Test that the llm_semantic_column_analysis_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'llm_column_semantics' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot perform semantic analysis: missing required data" in result_state['error_messages'][0]
+    assert "llm_column_semantics" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "Cannot perform semantic analysis: missing required data"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output')
-def test_llm_semantic_column_analysis_node_success(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output")
+def test_llm_semantic_column_analysis_node_success(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the llm_semantic_column_analysis_node successfully analyzes column semantics."""
     # In real-world scenarios, we need to mock both the prompt formatting and LLM response
     # This simulates a successful LLM analysis despite potential missing prompt templates
-    
+
     # Mock the format_prompt to avoid the missing template file error
     mock_format_prompt.return_value = "Analyze column semantics for the given data"
-    
+
     # Mock the LLM response with realistic column semantics
     mock_llm_response_data = {
-        'semantic_type': 'Identifier',
-        'neo4j_role': 'PRIMARY_KEY',
-        'description': 'Unique identifier for the entity',
-        'related_entity': ''
+        "semantic_type": "Identifier",
+        "neo4j_role": "PRIMARY_KEY",
+        "description": "Unique identifier for the entity",
+        "related_entity": "",
     }
     mock_call_llm.return_value = mock_llm_response_data
-    
+
     # Create initial state with DataFrame and column analytics
     # Using the actual field names from the implementation
     column_analytics = {
-        'id': {'data_type': 'numeric', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': [1, 2, 3, 4, 5], 'missing_percentage': 0.0},
-        'name': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': ['John Doe', 'Jane Smith', 'Bob Johnson', 'Alice Brown', 'Charlie Wilson'], 'missing_percentage': 0.0},
-        'age': {'data_type': 'numeric', 'uniqueness_ratio': 0.8, 'cardinality': 4, 'patterns': [], 'sample_values': [30, 25, 40, 35, 28], 'missing_percentage': 0.0},
-        'email': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': ['@'], 'sample_values': ['john@example.com', 'jane@example.com', 'bob@example.com', 'alice@example.com', 'charlie@example.com'], 'missing_percentage': 0.0},
-        'city': {'data_type': 'string', 'uniqueness_ratio': 0.8, 'cardinality': 4, 'patterns': [], 'sample_values': ['New York', 'Los Angeles', 'Chicago', 'Houston', 'Phoenix'], 'missing_percentage': 0.0}
+        "id": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [1, 2, 3, 4, 5],
+            "missing_percentage": 0.0,
+        },
+        "name": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [
+                "John Doe",
+                "Jane Smith",
+                "Bob Johnson",
+                "Alice Brown",
+                "Charlie Wilson",
+            ],
+            "missing_percentage": 0.0,
+        },
+        "age": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 0.8,
+            "cardinality": 4,
+            "patterns": [],
+            "sample_values": [30, 25, 40, 35, 28],
+            "missing_percentage": 0.0,
+        },
+        "email": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": ["@"],
+            "sample_values": [
+                "john@example.com",
+                "jane@example.com",
+                "bob@example.com",
+                "alice@example.com",
+                "charlie@example.com",
+            ],
+            "missing_percentage": 0.0,
+        },
+        "city": {
+            "data_type": "string",
+            "uniqueness_ratio": 0.8,
+            "cardinality": 4,
+            "patterns": [],
+            "sample_values": [
+                "New York",
+                "Los Angeles",
+                "Chicago",
+                "Houston",
+                "Phoenix",
+            ],
+            "missing_percentage": 0.0,
+        },
     }
-    
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe,
-        'column_analytics': column_analytics,
-        'csv_file_path': '/path/to/customers.csv',  # For primary entity inference
-        'error_messages': []
-    })
-    
+
+    initial_state = GraphState.from_dict(
+        {
+            "processed_dataframe": sample_dataframe,
+            "column_analytics": column_analytics,
+            "csv_file_path": "/path/to/customers.csv",  # For primary entity inference
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # Check that the semantic analysis results were added to the state
-    assert 'llm_column_semantics' in result_state
-    assert isinstance(result_state['llm_column_semantics'], dict)
-    assert len(result_state['llm_column_semantics']) == len(sample_dataframe.columns)
-    
+    assert "llm_column_semantics" in result_state
+    assert isinstance(result_state["llm_column_semantics"], dict)
+    assert len(result_state["llm_column_semantics"]) == len(sample_dataframe.columns)
+
     # In a real-world scenario, we'd check that the semantic analysis has the expected structure
     # rather than specific values which would depend on the LLM response
     for column in sample_dataframe.columns:
-        assert column in result_state['llm_column_semantics']
-        column_semantics = result_state['llm_column_semantics'][column]
-        assert 'semantic_type' in column_semantics
-        assert 'neo4j_role' in column_semantics
-        assert 'description' in column_semantics
-        assert 'related_entity' in column_semantics
-    
+        assert column in result_state["llm_column_semantics"]
+        column_semantics = result_state["llm_column_semantics"][column]
+        assert "semantic_type" in column_semantics
+        assert "neo4j_role" in column_semantics
+        assert "description" in column_semantics
+        assert "related_entity" in column_semantics
+
     # Verify the LLM was called the expected number of times (once per column)
     assert mock_call_llm.call_count == len(sample_dataframe.columns)
 
+
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output')
-def test_llm_semantic_column_analysis_node_llm_error(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output")
+def test_llm_semantic_column_analysis_node_llm_error(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the llm_semantic_column_analysis_node handles LLM errors gracefully."""
     # In real-world scenarios, LLM calls can fail for various reasons:
     # - API rate limits
     # - Network issues
     # - Invalid responses
     # This test simulates LLM failures and verifies the fallback behavior
-    
+
     # Mock the format_prompt to avoid the missing template file error
     mock_format_prompt.return_value = "Analyze column semantics for the given data"
-    
+
     # Mock the LLM to raise an exception (simulating an API failure)
     mock_call_llm.side_effect = Exception("LLM API rate limit exceeded")
-    
+
     # Create initial state with DataFrame and column analytics using the actual field names
     column_analytics = {
-        'id': {'data_type': 'numeric', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': [1, 2, 3, 4, 5], 'missing_percentage': 0.0},
-        'name': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': ['John Doe', 'Jane Smith'], 'missing_percentage': 0.0}
+        "id": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [1, 2, 3, 4, 5],
+            "missing_percentage": 0.0,
+        },
+        "name": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": ["John Doe", "Jane Smith"],
+            "missing_percentage": 0.0,
+        },
     }
-    
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe[['id', 'name']],  # Just use two columns for simplicity
-        'column_analytics': column_analytics,
-        'csv_file_path': '/path/to/customers.csv',
-        'error_messages': []
-    })
-    
+
+    initial_state = GraphState.from_dict(
+        {
+            "processed_dataframe": sample_dataframe[
+                ["id", "name"]
+            ],  # Just use two columns for simplicity
+            "column_analytics": column_analytics,
+            "csv_file_path": "/path/to/customers.csv",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # In a real-world scenario with LLM failures, the node should provide fallback classifications
     # rather than failing completely, ensuring the pipeline can continue
-    assert 'llm_column_semantics' in result_state
-    assert len(result_state['llm_column_semantics']) == 2
-    
+    assert "llm_column_semantics" in result_state
+    assert len(result_state["llm_column_semantics"]) == 2
+
     # Check that each column has fallback semantics with all expected fields
-    for column in ['id', 'name']:
-        assert column in result_state['llm_column_semantics']
-        column_semantics = result_state['llm_column_semantics'][column]
-        
+    for column in ["id", "name"]:
+        assert column in result_state["llm_column_semantics"]
+        column_semantics = result_state["llm_column_semantics"][column]
+
         # Verify the fallback values match what we'd expect in a real scenario
-        assert column_semantics['semantic_type'] == 'Unknown'
-        assert column_semantics['neo4j_role'] == 'PROPERTY'
-        assert 'Error in LLM analysis' in column_semantics['description']
-        assert 'related_entity' in column_semantics
-        
+        assert column_semantics["semantic_type"] == "Unknown"
+        assert column_semantics["neo4j_role"] == "PROPERTY"
+        assert "Error in LLM analysis" in column_semantics["description"]
+        assert "related_entity" in column_semantics
+
     # Verify that the error was properly logged but didn't stop the process
     assert mock_call_llm.call_count > 0

--- a/Tabular_to_Neo4j/tests/nodes/db_schema/test_cypher_generation.py
+++ b/Tabular_to_Neo4j/tests/nodes/db_schema/test_cypher_generation.py
@@ -5,138 +5,182 @@ Tests for the cypher generation node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.db_schema.cypher_generation import generate_cypher_templates_node
+from Tabular_to_Neo4j.nodes.db_schema.cypher_generation import (
+    generate_cypher_templates_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_generate_cypher_templates_node_missing_data(runnable_config):
     """Test that the generate_cypher_templates_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot generate Cypher templates" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot generate Cypher templates" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node successfully generates Cypher templates."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-        'constraint_queries': ['CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'],
-        'index_queries': ['CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)'],
-        'example_queries': ['MATCH (p:Person) RETURN p']
+        "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+        "constraint_queries": [
+            "CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+        ],
+        "index_queries": [
+            "CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)"
+        ],
+        "example_queries": ["MATCH (p:Person) RETURN p"],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that the Cypher templates were added to the state
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'constraint_queries' in result_state['cypher_query_templates']
-    assert 'index_queries' in result_state['cypher_query_templates']
-    assert 'example_queries' in result_state['cypher_query_templates']
-    assert 'LOAD CSV' in result_state['cypher_query_templates']['load_query']
-    assert len(result_state['cypher_query_templates']['constraint_queries']) == 1
-    assert len(result_state['cypher_query_templates']['index_queries']) == 1
-    assert len(result_state['cypher_query_templates']['example_queries']) == 1
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "constraint_queries" in result_state["cypher_query_templates"]
+    assert "index_queries" in result_state["cypher_query_templates"]
+    assert "example_queries" in result_state["cypher_query_templates"]
+    assert "LOAD CSV" in result_state["cypher_query_templates"]["load_query"]
+    assert len(result_state["cypher_query_templates"]["constraint_queries"]) == 1
+    assert len(result_state["cypher_query_templates"]["index_queries"]) == 1
+    assert len(result_state["cypher_query_templates"]["example_queries"]) == 1
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_empty_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_empty_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node handles empty LLM responses."""
     # Mock empty LLM response
     mock_call_llm.return_value = {
-        'load_query': '',
-        'constraint_queries': [],
-        'index_queries': [],
-        'example_queries': []
+        "load_query": "",
+        "constraint_queries": [],
+        "index_queries": [],
+        "example_queries": [],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that fallback templates were created
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'LOAD CSV' in result_state['cypher_query_templates']['load_query']
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "LOAD CSV" in result_state["cypher_query_templates"]["load_query"]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that fallback templates were created
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'Error generating Cypher templates' in result_state['error_messages'][0]
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "Error generating Cypher templates" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/db_schema/test_schema_finalization.py
+++ b/Tabular_to_Neo4j/tests/nodes/db_schema/test_schema_finalization.py
@@ -5,212 +5,252 @@ Tests for the schema finalization node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.db_schema.schema_finalization import synthesize_final_schema_node
+from Tabular_to_Neo4j.nodes.db_schema.schema_finalization import (
+    synthesize_final_schema_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_synthesize_final_schema_node_missing_data(runnable_config):
     """Test that the synthesize_final_schema_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot synthesize final schema" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot synthesize final schema" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node successfully synthesizes the final schema."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'node_labels': [
+        "node_labels": [
             {
-                'label': 'Person',
-                'description': 'Represents a person',
-                'is_primary': True
+                "label": "Person",
+                "description": "Represents a person",
+                "is_primary": True,
             }
         ],
-        'relationship_types': [
+        "relationship_types": [
             {
-                'type': 'LIVES_IN',
-                'source_label': 'Person',
-                'target_label': 'City',
-                'description': 'Indicates where a person lives',
-                'cardinality': 'MANY_TO_ONE'
+                "type": "LIVES_IN",
+                "source_label": "Person",
+                "target_label": "City",
+                "description": "Indicates where a person lives",
+                "cardinality": "MANY_TO_ONE",
             }
         ],
-        'property_keys': [
+        "property_keys": [
             {
-                'key': 'id',
-                'data_type': 'STRING',
-                'description': 'Unique identifier for a person',
-                'belongs_to': 'Person',
-                'is_identifier': True
+                "key": "id",
+                "data_type": "STRING",
+                "description": "Unique identifier for a person",
+                "belongs_to": "Person",
+                "is_identifier": True,
             },
             {
-                'key': 'name',
-                'data_type': 'STRING',
-                'description': 'Name of a person',
-                'belongs_to': 'Person',
-                'is_identifier': False
+                "key": "name",
+                "data_type": "STRING",
+                "description": "Name of a person",
+                "belongs_to": "Person",
+                "is_identifier": False,
+            },
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "entity_type": "Person",
+                "property_key": "id",
+                "description": "Ensures person id is unique",
             }
         ],
-        'constraints': [
+        "indexes": [
             {
-                'type': 'UNIQUENESS',
-                'entity_type': 'Person',
-                'property_key': 'id',
-                'description': 'Ensures person id is unique'
+                "type": "BTREE",
+                "entity_type": "Person",
+                "property_key": "name",
+                "description": "Index for faster name lookups",
             }
         ],
-        'indexes': [
-            {
-                'type': 'BTREE',
-                'entity_type': 'Person',
-                'property_key': 'name',
-                'description': 'Index for faster name lookups'
-            }
-        ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': [
-            {
-                'source_entity': 'Person',
-                'relationship_type': 'LIVES_IN',
-                'target_entity': 'City',
-                'properties': [],
-                'cardinality': 'MANY_TO_ONE'
-            }
-        ],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-            'constraint_queries': ['CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'],
-            'index_queries': ['CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)'],
-            'example_queries': ['MATCH (p:Person) RETURN p']
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [
+                {
+                    "source_entity": "Person",
+                    "relationship_type": "LIVES_IN",
+                    "target_entity": "City",
+                    "properties": [],
+                    "cardinality": "MANY_TO_ONE",
+                }
+            ],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+                "constraint_queries": [
+                    "CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+                ],
+                "index_queries": [
+                    "CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)"
+                ],
+                "example_queries": ["MATCH (p:Person) RETURN p"],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that the final schema was added to the state
-    assert 'inferred_neo4j_schema' in result_state
-    assert 'node_labels' in result_state['inferred_neo4j_schema']
-    assert 'relationship_types' in result_state['inferred_neo4j_schema']
-    assert 'property_keys' in result_state['inferred_neo4j_schema']
-    assert 'constraints' in result_state['inferred_neo4j_schema']
-    assert 'indexes' in result_state['inferred_neo4j_schema']
-    assert 'cypher_templates' in result_state['inferred_neo4j_schema']
-    assert len(result_state['inferred_neo4j_schema']['node_labels']) == 1
-    assert len(result_state['inferred_neo4j_schema']['relationship_types']) == 1
-    assert len(result_state['inferred_neo4j_schema']['property_keys']) == 2
-    assert len(result_state['inferred_neo4j_schema']['constraints']) == 1
-    assert len(result_state['inferred_neo4j_schema']['indexes']) == 1
+    assert "inferred_neo4j_schema" in result_state
+    assert "node_labels" in result_state["inferred_neo4j_schema"]
+    assert "relationship_types" in result_state["inferred_neo4j_schema"]
+    assert "property_keys" in result_state["inferred_neo4j_schema"]
+    assert "constraints" in result_state["inferred_neo4j_schema"]
+    assert "indexes" in result_state["inferred_neo4j_schema"]
+    assert "cypher_templates" in result_state["inferred_neo4j_schema"]
+    assert len(result_state["inferred_neo4j_schema"]["node_labels"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["relationship_types"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["property_keys"]) == 2
+    assert len(result_state["inferred_neo4j_schema"]["constraints"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["indexes"]) == 1
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_empty_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_empty_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node handles empty LLM responses."""
     # Mock empty LLM response
     mock_call_llm.return_value = {
-        'node_labels': [],
-        'relationship_types': [],
-        'property_keys': [],
-        'constraints': [],
-        'indexes': []
+        "node_labels": [],
+        "relationship_types": [],
+        "property_keys": [],
+        "constraints": [],
+        "indexes": [],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': [],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-            'constraint_queries': [],
-            'index_queries': [],
-            'example_queries': []
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+                "constraint_queries": [],
+                "index_queries": [],
+                "example_queries": [],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that fallback schema was created
-    assert 'inferred_neo4j_schema' in result_state
-    assert len(result_state['inferred_neo4j_schema']['node_labels']) > 0
-    assert len(result_state['inferred_neo4j_schema']['property_keys']) > 0
+    assert "inferred_neo4j_schema" in result_state
+    assert len(result_state["inferred_neo4j_schema"]["node_labels"]) > 0
+    assert len(result_state["inferred_neo4j_schema"]["property_keys"]) > 0
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
-            }
-        },
-        'entity_relationships': [],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id})',
-            'constraint_queries': [],
-            'index_queries': [],
-            'example_queries': []
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                }
+            },
+            "entity_relationships": [],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id})',
+                "constraint_queries": [],
+                "index_queries": [],
+                "example_queries": [],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that fallback schema was created
-    assert 'inferred_neo4j_schema' in result_state
-    assert 'node_labels' in result_state['inferred_neo4j_schema']
-    assert 'property_keys' in result_state['inferred_neo4j_schema']
-    assert 'Error synthesizing final schema' in result_state['error_messages'][0]
+    assert "inferred_neo4j_schema" in result_state
+    assert "node_labels" in result_state["inferred_neo4j_schema"]
+    assert "property_keys" in result_state["inferred_neo4j_schema"]
+    assert "Error synthesizing final schema" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_classification.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_classification.py
@@ -4,97 +4,120 @@ Tests for the entity classification node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.entity_inference.entity_classification import classify_entities_properties_node
+from Tabular_to_Neo4j.nodes.entity_inference.entity_classification import (
+    classify_entities_properties_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_classify_entities_properties_node_missing_data(runnable_config):
     """Test that the classify_entities_properties_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot classify entities/properties" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot classify entities/properties" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output')
-def test_classify_entities_properties_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output"
+)
+def test_classify_entities_properties_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the classify_entities_properties_node successfully classifies entities and properties."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'classification': 'entity',
-        'entity_type': 'Person',
-        'relationship_to_primary': 'IS_A',
-        'property_name': 'person_id',
-        'reasoning': 'This is a unique identifier for a person.'
+        "classification": "entity",
+        "entity_type": "Person",
+        "relationship_to_primary": "IS_A",
+        "property_name": "person_id",
+        "reasoning": "This is a unique identifier for a person.",
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'final_header': ['id', 'name', 'age'],
-        'column_analytics': {
-            'id': {'uniqueness': 1.0, 'cardinality': 100, 'data_type': 'integer'},
-            'name': {'uniqueness': 0.9, 'cardinality': 90, 'data_type': 'string'},
-            'age': {'uniqueness': 0.1, 'cardinality': 10, 'data_type': 'integer'}
-        },
-        'llm_column_semantics': {
-            'id': {'semantic_type': 'identifier', 'neo4j_role': 'ID'},
-            'name': {'semantic_type': 'name', 'neo4j_role': 'PROPERTY'},
-            'age': {'semantic_type': 'age', 'neo4j_role': 'PROPERTY'}
-        },
-        'processed_dataframe': None
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "final_header": ["id", "name", "age"],
+            "column_analytics": {
+                "id": {"uniqueness": 1.0, "cardinality": 100, "data_type": "integer"},
+                "name": {"uniqueness": 0.9, "cardinality": 90, "data_type": "string"},
+                "age": {"uniqueness": 0.1, "cardinality": 10, "data_type": "integer"},
+            },
+            "llm_column_semantics": {
+                "id": {"semantic_type": "identifier", "neo4j_role": "ID"},
+                "name": {"semantic_type": "name", "neo4j_role": "PROPERTY"},
+                "age": {"semantic_type": "age", "neo4j_role": "PROPERTY"},
+            },
+            "processed_dataframe": None,
+        }
+    )
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that the classification was added to the state
-    assert 'entity_property_classification' in result_state
-    assert len(result_state['entity_property_classification']) == 3
-    assert result_state['entity_property_classification']['id']['classification'] == 'entity'
-    assert result_state['entity_property_classification']['id']['entity_type'] == 'Person'
+    assert "entity_property_classification" in result_state
+    assert len(result_state["entity_property_classification"]) == 3
+    assert (
+        result_state["entity_property_classification"]["id"]["classification"]
+        == "entity"
+    )
+    assert (
+        result_state["entity_property_classification"]["id"]["entity_type"] == "Person"
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output')
-def test_classify_entities_properties_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output"
+)
+def test_classify_entities_properties_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the classify_entities_properties_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'final_header': ['id', 'name', 'age'],
-        'column_analytics': {
-            'id': {'uniqueness': 1.0, 'cardinality': 100, 'data_type': 'integer'},
-            'name': {'uniqueness': 0.9, 'cardinality': 90, 'data_type': 'string'},
-            'age': {'uniqueness': 0.1, 'cardinality': 10, 'data_type': 'integer'}
-        },
-        'llm_column_semantics': {
-            'id': {'semantic_type': 'identifier', 'neo4j_role': 'ID'},
-            'name': {'semantic_type': 'name', 'neo4j_role': 'PROPERTY'},
-            'age': {'semantic_type': 'age', 'neo4j_role': 'PROPERTY'}
-        },
-        'processed_dataframe': None
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "final_header": ["id", "name", "age"],
+            "column_analytics": {
+                "id": {"uniqueness": 1.0, "cardinality": 100, "data_type": "integer"},
+                "name": {"uniqueness": 0.9, "cardinality": 90, "data_type": "string"},
+                "age": {"uniqueness": 0.1, "cardinality": 10, "data_type": "integer"},
+            },
+            "llm_column_semantics": {
+                "id": {"semantic_type": "identifier", "neo4j_role": "ID"},
+                "name": {"semantic_type": "name", "neo4j_role": "PROPERTY"},
+                "age": {"semantic_type": "age", "neo4j_role": "PROPERTY"},
+            },
+            "processed_dataframe": None,
+        }
+    )
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that the classification was added to the state with fallback values
-    assert 'entity_property_classification' in result_state
-    assert len(result_state['entity_property_classification']) == 3
-    assert 'LLM entity classification failed' in result_state['error_messages'][0]
+    assert "entity_property_classification" in result_state
+    assert len(result_state["entity_property_classification"]) == 3
+    assert "LLM entity classification failed" in result_state["error_messages"][0]
     # Check that a fallback classification was used
-    assert result_state['entity_property_classification']['id']['classification'] in ['entity', 'property']
+    assert result_state["entity_property_classification"]["id"]["classification"] in [
+        "entity",
+        "property",
+    ]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_reconciliation.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_reconciliation.py
@@ -5,61 +5,68 @@ Tests for the entity reconciliation node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.entity_reconciliation import reconcile_entity_property_node
+from Tabular_to_Neo4j.nodes.entity_inference.entity_reconciliation import (
+    reconcile_entity_property_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_reconcile_entity_property_node_missing_data(runnable_config):
     """Test that the reconcile_entity_property_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = reconcile_entity_property_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot reconcile entity/property classifications" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "Cannot reconcile entity/property classifications"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
 def test_reconcile_entity_property_node_success(runnable_config):
     """Test that the reconcile_entity_property_node successfully reconciles entity and property classifications."""
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_classification': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'property_name': 'id',
-                'reasoning': 'This is a unique identifier for a person.',
-                'analytics': {'uniqueness': 1.0},
-                'semantics': {'semantic_type': 'identifier'}
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_classification": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "property_name": "id",
+                    "reasoning": "This is a unique identifier for a person.",
+                    "analytics": {"uniqueness": 1.0},
+                    "semantics": {"semantic_type": "identifier"},
+                },
+                "name": {
+                    "column_name": "name",
+                    "classification": "entity_property",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "property_name": "name",
+                    "reasoning": "This is a property of a person.",
+                    "analytics": {"uniqueness": 0.9},
+                    "semantics": {"semantic_type": "name"},
+                },
             },
-            'name': {
-                'column_name': 'name',
-                'classification': 'entity_property',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'property_name': 'name',
-                'reasoning': 'This is a property of a person.',
-                'analytics': {'uniqueness': 0.9},
-                'semantics': {'semantic_type': 'name'}
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = reconcile_entity_property_node(initial_state, runnable_config)
-    
+
     # Check that the consensus was added to the state
-    assert 'entity_property_consensus' in result_state
-    assert len(result_state['entity_property_consensus']) == 2
-    assert 'id' in result_state['entity_property_consensus']
-    assert 'name' in result_state['entity_property_consensus']
+    assert "entity_property_consensus" in result_state
+    assert len(result_state["entity_property_consensus"]) == 2
+    assert "id" in result_state["entity_property_consensus"]
+    assert "name" in result_state["entity_property_consensus"]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_property_mapping.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_property_mapping.py
@@ -5,113 +5,118 @@ Tests for the property mapping node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.property_mapping import map_properties_to_entities_node
+from Tabular_to_Neo4j.nodes.entity_inference.property_mapping import (
+    map_properties_to_entities_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_map_properties_to_entities_node_missing_data(runnable_config):
     """Test that the map_properties_to_entities_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot map properties to entities" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot map properties to entities" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output')
-def test_map_properties_to_entities_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.property_mapping.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output"
+)
+def test_map_properties_to_entities_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the map_properties_to_entities_node successfully maps properties to entities."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'properties': [
-            {
-                'column_name': 'id',
-                'property_key': 'id',
-                'is_identifier': True
-            },
-            {
-                'column_name': 'name',
-                'property_key': 'name',
-                'is_identifier': False
-            }
+        "properties": [
+            {"column_name": "id", "property_key": "id", "is_identifier": True},
+            {"column_name": "name", "property_key": "name", "is_identifier": False},
         ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_consensus': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'id',
-                'semantic_type': 'identifier',
-                'confidence': 0.9,
-                'reasoning': 'This is a unique identifier for a person.'
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_consensus": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "id",
+                    "semantic_type": "identifier",
+                    "confidence": 0.9,
+                    "reasoning": "This is a unique identifier for a person.",
+                },
+                "name": {
+                    "column_name": "name",
+                    "classification": "entity_property",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "name",
+                    "semantic_type": "name",
+                    "confidence": 0.8,
+                    "reasoning": "This is a property of a person.",
+                },
             },
-            'name': {
-                'column_name': 'name',
-                'classification': 'entity_property',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'name',
-                'semantic_type': 'name',
-                'confidence': 0.8,
-                'reasoning': 'This is a property of a person.'
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that the mapping was added to the state
-    assert 'property_entity_mapping' in result_state
-    assert 'Person' in result_state['property_entity_mapping']
-    assert result_state['property_entity_mapping']['Person']['type'] == 'entity'
-    assert len(result_state['property_entity_mapping']['Person']['properties']) == 2
+    assert "property_entity_mapping" in result_state
+    assert "Person" in result_state["property_entity_mapping"]
+    assert result_state["property_entity_mapping"]["Person"]["type"] == "entity"
+    assert len(result_state["property_entity_mapping"]["Person"]["properties"]) == 2
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output')
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output"
+)
 def test_map_properties_to_entities_node_llm_error(mock_call_llm, runnable_config):
     """Test that the map_properties_to_entities_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_consensus': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'id',
-                'semantic_type': 'identifier',
-                'confidence': 0.9,
-                'reasoning': 'This is a unique identifier for a person.'
-            }
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_consensus": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "id",
+                    "semantic_type": "identifier",
+                    "confidence": 0.9,
+                    "reasoning": "This is a unique identifier for a person.",
+                }
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that the mapping was added to the state with fallback values
-    assert 'property_entity_mapping' in result_state
-    assert 'Person' in result_state['property_entity_mapping']
-    assert result_state['property_entity_mapping']['Person']['type'] == 'entity'
-    assert len(result_state['property_entity_mapping']['Person']['properties']) == 1
-    assert 'Error mapping properties for entity' in result_state['error_messages'][0]
+    assert "property_entity_mapping" in result_state
+    assert "Person" in result_state["property_entity_mapping"]
+    assert result_state["property_entity_mapping"]["Person"]["type"] == "entity"
+    assert len(result_state["property_entity_mapping"]["Person"]["properties"]) == 1
+    assert "Error mapping properties for entity" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_relationship_inference.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_relationship_inference.py
@@ -5,157 +5,207 @@ Tests for the relationship inference node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.relationship_inference import infer_entity_relationships_node
+from Tabular_to_Neo4j.nodes.entity_inference.relationship_inference import (
+    infer_entity_relationships_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_infer_entity_relationships_node_missing_data(runnable_config):
     """Test that the infer_entity_relationships_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot infer entity relationships" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot infer entity relationships" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
-def test_infer_entity_relationships_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
+def test_infer_entity_relationships_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the infer_entity_relationships_node successfully infers relationships."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'relationships': [
+        "relationships": [
             {
-                'source_entity': 'Person',
-                'relationship_type': 'LIVES_IN',
-                'target_entity': 'City',
-                'properties': [],
-                'cardinality': 'MANY_TO_ONE'
+                "source_entity": "Person",
+                "relationship_type": "LIVES_IN",
+                "target_entity": "City",
+                "properties": [],
+                "cardinality": "MANY_TO_ONE",
             }
         ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "city_name",
+                            "property_key": "cityName",
+                            "is_identifier": False,
+                        },
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True},
-                    {'column_name': 'city_name', 'property_key': 'cityName', 'is_identifier': False}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that the relationships were added to the state
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) == 1
-    assert result_state['entity_relationships'][0]['source_entity'] == 'Person'
-    assert result_state['entity_relationships'][0]['relationship_type'] == 'LIVES_IN'
-    assert result_state['entity_relationships'][0]['target_entity'] == 'City'
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) == 1
+    assert result_state["entity_relationships"][0]["source_entity"] == "Person"
+    assert result_state["entity_relationships"][0]["relationship_type"] == "LIVES_IN"
+    assert result_state["entity_relationships"][0]["target_entity"] == "City"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
 def test_infer_entity_relationships_node_llm_error(mock_call_llm, runnable_config):
     """Test that the infer_entity_relationships_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that default relationships were created
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) > 0
-    assert 'LLM relationship inference failed' in result_state['error_messages'][0]
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) > 0
+    assert "LLM relationship inference failed" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
-def test_infer_entity_relationships_node_no_relationships(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
+def test_infer_entity_relationships_node_no_relationships(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the infer_entity_relationships_node creates default relationships when none are inferred."""
     # Mock LLM response with no relationships
-    mock_call_llm.return_value = {
-        'relationships': []
-    }
-    
+    mock_call_llm.return_value = {"relationships": []}
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that default relationships were created
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) > 0
-    assert result_state['entity_relationships'][0]['source_entity'] == 'Person'
-    assert 'HAS_CITY' in result_state['entity_relationships'][0]['relationship_type']
-    assert result_state['entity_relationships'][0]['target_entity'] == 'City'
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) > 0
+    assert result_state["entity_relationships"][0]["source_entity"] == "Person"
+    assert "HAS_CITY" in result_state["entity_relationships"][0]["relationship_type"]
+    assert result_state["entity_relationships"][0]["target_entity"] == "City"

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_inference.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_inference.py
@@ -4,101 +4,124 @@ Tests for the header inference node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_inference import infer_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_inference import (
+    infer_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_infer_header_llm_node_no_dataframe(runnable_config):
     """Test that the infer_header_llm_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot infer header" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot infer header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_success(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_success(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the infer_header_llm_node successfully infers headers."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM response
     mock_call_llm.return_value = list(sample_dataframe.columns)
-    
+
     # Create initial state with a DataFrame but no headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were inferred
-    assert 'inferred_header' in result_state
-    assert result_state['inferred_header'] == list(sample_dataframe.columns)
-    assert result_state['final_header'] == list(sample_dataframe.columns)
-    assert result_state['error_messages'] == []
-    
+    assert "inferred_header" in result_state
+    assert result_state["inferred_header"] == list(sample_dataframe.columns)
+    assert result_state["final_header"] == list(sample_dataframe.columns)
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "infer_header"
+    assert mock_call_llm.call_args[1]["state_name"] == "infer_header"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the infer_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM to return an invalid response (not a list)
     mock_call_llm.return_value = {"error": "Not a list of headers"}
-    
+
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of headers" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM did not return a list of headers" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_wrong_length(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_wrong_length(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the infer_header_llm_node handles LLM responses with wrong number of headers."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM to return a list with wrong number of headers
     mock_call_llm.return_value = ["header1", "header2"]  # Not enough headers
-    
+
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM returned 2 headers, but CSV has" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM returned 2 headers, but CSV has" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_translation.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_translation.py
@@ -4,102 +4,142 @@ Tests for the header translation node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_translation import translate_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_translation import (
+    translate_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_translate_header_llm_node_missing_header(runnable_config):
     """Test that the translate_header_llm_node handles missing header."""
     # Create initial state without a header
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot translate header" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot translate header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_success(mock_call_llm, mock_format_prompt, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config, mock_llm_response
+):
     """Test that the translate_header_llm_node successfully translates headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM response
-    mock_call_llm.return_value = ["id", "name", "age", "email", "city"]  # Translated headers
-    
+    mock_call_llm.return_value = [
+        "id",
+        "name",
+        "age",
+        "email",
+        "city",
+    ]  # Translated headers
+
     # Create initial state with headers and language info
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],  # Spanish headers
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": [
+                "id",
+                "nombre",
+                "edad",
+                "correo",
+                "ciudad",
+            ],  # Spanish headers
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were translated
-    assert 'translated_header' in result_state
-    assert result_state['translated_header'] == ["id", "name", "age", "email", "city"]
-    assert result_state['final_header'] == ["id", "name", "age", "email", "city"]
-    assert result_state['error_messages'] == []
-    
+    assert "translated_header" in result_state
+    assert result_state["translated_header"] == ["id", "name", "age", "email", "city"]
+    assert result_state["final_header"] == ["id", "name", "age", "email", "city"]
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name and is_translation flag
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "translate_header"
-    assert mock_call_llm.call_args[1]['is_translation'] is True
+    assert mock_call_llm.call_args[1]["state_name"] == "translate_header"
+    assert mock_call_llm.call_args[1]["is_translation"] is True
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the translate_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM to return an invalid response (not a list)
     mock_call_llm.return_value = {"error": "Not a list of headers"}
-    
+
     # Create initial state with headers
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": ["id", "nombre", "edad", "correo", "ciudad"],
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of translated headers" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "LLM did not return a list of translated headers"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_wrong_length(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_wrong_length(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the translate_header_llm_node handles LLM responses with wrong number of headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM to return a list with wrong number of headers
     mock_call_llm.return_value = ["id", "name", "age"]  # Missing two headers
-    
+
     # Create initial state with headers
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": ["id", "nombre", "edad", "correo", "ciudad"],
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM returned 3 headers, but original has 5 columns" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "LLM returned 3 headers, but original has 5 columns"
+        in result_state["error_messages"][0]
+    )

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_validation.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_validation.py
@@ -4,29 +4,39 @@ Tests for the header validation node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_validation import validate_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_validation import (
+    validate_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_validate_header_llm_node_missing_data(runnable_config):
     """Test that the validate_header_llm_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'validated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot validate header" in result_state['error_messages'][0]
+    assert "validated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot validate header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_correct_headers(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_correct_headers(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the validate_header_llm_node handles correct headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
@@ -34,63 +44,97 @@ def test_validate_header_llm_node_correct_headers(mock_call_llm, mock_format_pro
     mock_call_llm.return_value = {
         "is_correct": True,
         "validated_header": list(sample_dataframe.columns),
-        "suggestions": ""
+        "suggestions": "",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were validated
-    assert 'validated_header' in result_state
-    assert result_state['validated_header'] == list(sample_dataframe.columns)
-    assert result_state['final_header'] == list(sample_dataframe.columns)  # Unchanged since headers are correct
-    assert result_state['error_messages'] == []
-    
+    assert "validated_header" in result_state
+    assert result_state["validated_header"] == list(sample_dataframe.columns)
+    assert result_state["final_header"] == list(
+        sample_dataframe.columns
+    )  # Unchanged since headers are correct
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "validate_header"
+    assert mock_call_llm.call_args[1]["state_name"] == "validate_header"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_improved_headers(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_improved_headers(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the validate_header_llm_node improves headers when needed."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
     # Mock the LLM response to indicate headers need improvement
     mock_call_llm.return_value = {
         "is_correct": False,
-        "validated_header": ["identifier", "full_name", "years", "email_address", "location"],
-        "suggestions": "Made headers more descriptive"
+        "validated_header": [
+            "identifier",
+            "full_name",
+            "years",
+            "email_address",
+            "location",
+        ],
+        "suggestions": "Made headers more descriptive",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were improved
-    assert 'validated_header' in result_state
-    assert result_state['validated_header'] == ["identifier", "full_name", "years", "email_address", "location"]
-    assert result_state['final_header'] == ["identifier", "full_name", "years", "email_address", "location"]
-    assert result_state['error_messages'] == []
+    assert "validated_header" in result_state
+    assert result_state["validated_header"] == [
+        "identifier",
+        "full_name",
+        "years",
+        "email_address",
+        "location",
+    ]
+    assert result_state["final_header"] == [
+        "identifier",
+        "full_name",
+        "years",
+        "email_address",
+        "location",
+    ]
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the validate_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
@@ -98,19 +142,21 @@ def test_validate_header_llm_node_invalid_response(mock_call_llm, mock_format_pr
     mock_call_llm.return_value = {
         "is_correct": False,
         "validated_header": "Not a list",  # Should be a list
-        "suggestions": "Made headers more descriptive"
+        "suggestions": "Made headers more descriptive",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of headers" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM did not return a list of headers" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/input/test_csv_loader.py
+++ b/Tabular_to_Neo4j/tests/nodes/input/test_csv_loader.py
@@ -10,56 +10,61 @@ from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 from Tabular_to_Neo4j.nodes.input.csv_loader import load_csv_node
 
+
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_success(mock_load_csv, sample_csv_content, runnable_config):
     """Test that the load_csv_node successfully loads a CSV file."""
     # Mock the load_csv_safely function to return a valid DataFrame
-    mock_df = pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
-    mock_load_csv.return_value = (mock_df, ['col1', 'col2'], 'utf-8')
-    
+    mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+    mock_load_csv.return_value = (mock_df, ["col1", "col2"], "utf-8")
+
     # Create initial state with the CSV file path
-    initial_state = GraphState({
-        'csv_file_path': sample_csv_content,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": sample_csv_content, "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that the raw_dataframe was added to the state
-    assert 'raw_dataframe' in result_state
-    assert isinstance(result_state['raw_dataframe'], pd.DataFrame)
-    assert 'potential_header' in result_state
-    assert 'encoding_used' in result_state
-    assert len(result_state['raw_dataframe']) == 3  # 3 rows in our mock data
-    assert list(result_state['raw_dataframe'].columns) == ['col1', 'col2']
-    assert result_state['error_messages'] == []
+    assert "raw_dataframe" in result_state
+    assert isinstance(result_state["raw_dataframe"], pd.DataFrame)
+    assert "potential_header" in result_state
+    assert "encoding_used" in result_state
+    assert len(result_state["raw_dataframe"]) == 3  # 3 rows in our mock data
+    assert list(result_state["raw_dataframe"].columns) == ["col1", "col2"]
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_file_not_found(mock_load_csv, runnable_config):
     """Test that the load_csv_node handles file not found errors."""
     # Mock the load_csv_safely function to return None and an error
-    mock_load_csv.return_value = (None, ['File not found: /path/to/nonexistent/file.csv'], None)
-    
+    mock_load_csv.return_value = (
+        None,
+        ["File not found: /path/to/nonexistent/file.csv"],
+        None,
+    )
+
     # Create initial state with a non-existent CSV file path
-    initial_state = GraphState({
-        'csv_file_path': '/path/to/nonexistent/file.csv',
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": "/path/to/nonexistent/file.csv", "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'error_messages' in result_state
-    assert len(result_state['error_messages']) > 0
-    assert 'raw_dataframe' not in result_state
-    assert 'Failed to load CSV file' in result_state['error_messages'][0]
+    assert "error_messages" in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "raw_dataframe" not in result_state
+    assert "Failed to load CSV file" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_invalid_csv(mock_load_csv, runnable_config):
     """Test that the load_csv_node handles CSV files with parsing issues."""
     # In real-world scenarios, we often encounter CSV files with parsing issues such as:
@@ -67,48 +72,49 @@ def test_load_csv_node_invalid_csv(mock_load_csv, runnable_config):
     # - Quoting issues
     # - Encoding problems
     # This test simulates a CSV file that was loaded but had parsing warnings
-    
+
     # Create a mock DataFrame that represents what we could extract from a problematic CSV
-    mock_df = pd.DataFrame({
-        'id': [1, 2, 3, 4],
-        'name': ['John Doe', 'Jane Smith', 'Error in row', 'Bob Johnson'],
-        'email': ['john@example.com', 'jane@example.com', None, 'bob@example.com']
-    })
-    
+    mock_df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["John Doe", "Jane Smith", "Error in row", "Bob Johnson"],
+            "email": ["john@example.com", "jane@example.com", None, "bob@example.com"],
+        }
+    )
+
     # Realistic parsing errors that might be encountered
     mock_errors = [
-        'Warning: Line 3 has parsing issues - missing fields',
-        'Warning: Inconsistent quoting detected in file'
+        "Warning: Line 3 has parsing issues - missing fields",
+        "Warning: Inconsistent quoting detected in file",
     ]
-    
+
     # Set the mock return value
-    mock_load_csv.return_value = (mock_df, mock_errors, 'utf-8')
-    
+    mock_load_csv.return_value = (mock_df, mock_errors, "utf-8")
+
     # Create initial state with a CSV file path
     # In a real scenario, this would be a path to an actual file
-    initial_state = GraphState({
-        'csv_file_path': '/path/to/problematic_data.csv',
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": "/path/to/problematic_data.csv", "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that the raw_dataframe was added to the state despite the parsing issues
-    assert 'raw_dataframe' in result_state
-    assert isinstance(result_state['raw_dataframe'], pd.DataFrame)
-    assert len(result_state['raw_dataframe']) == 4  # 4 rows in our mock data
-    
+    assert "raw_dataframe" in result_state
+    assert isinstance(result_state["raw_dataframe"], pd.DataFrame)
+    assert len(result_state["raw_dataframe"]) == 4  # 4 rows in our mock data
+
     # Check that the warnings are handled appropriately
     # In the actual implementation, parsing warnings are logged but not added to error_messages
     # Instead, the implementation tracks specific issues in dedicated state fields
-    assert 'error_messages' in result_state
-    
+    assert "error_messages" in result_state
+
     # Check that columns with nulls were detected (this is what the implementation actually does)
-    assert 'columns_with_nulls' in result_state
-    assert 'email' in result_state['columns_with_nulls']
-    
+    assert "columns_with_nulls" in result_state
+    assert "email" in result_state["columns_with_nulls"]
+
     # Check that other expected fields are present
-    assert 'potential_header' in result_state
-    assert 'encoding_used' in result_state
-    assert result_state['encoding_used'] == 'utf-8'
+    assert "potential_header" in result_state
+    assert "encoding_used" in result_state
+    assert result_state["encoding_used"] == "utf-8"

--- a/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
+++ b/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
@@ -5,28 +5,34 @@ Tests for the header detection node.
 import pytest
 import pandas as pd
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.input.header_detection import detect_header_heuristic_node as detect_header_node
+from Tabular_to_Neo4j.nodes.input.header_detection import (
+    detect_header_heuristic_node as detect_header_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_detect_header_node_with_header(sample_dataframe, runnable_config):
     """Test that the detect_header_node correctly identifies a DataFrame with a header."""
     # Create initial state with a DataFrame that has a header
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'potential_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "potential_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Check that the header was detected
-    assert result_state['has_header_heuristic'] is True
-    assert 'final_header' in result_state
-    assert result_state['final_header'] == list(sample_dataframe.columns)
-    assert 'error_messages' in result_state
-    assert result_state['error_messages'] == []
+    assert result_state["has_header_heuristic"] is True
+    assert "final_header" in result_state
+    assert result_state["final_header"] == list(sample_dataframe.columns)
+    assert "error_messages" in result_state
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
 def test_detect_header_node_without_header(runnable_config):
@@ -34,52 +40,55 @@ def test_detect_header_node_without_header(runnable_config):
     # In real-world scenarios, we often encounter CSV files with data that could be mistaken for headers
     # This test simulates a dataset where the first row is clearly data, not a header
     # The challenge is that some heuristics might still detect patterns that look like headers
-    df_no_header = pd.DataFrame([
-        # First row is clearly data, not a header
-        ['A123', 'Product X', '12.99', '50', 'In Stock'],
-        ['B456', 'Product Y', '24.99', '30', 'In Stock'],
-        ['C789', 'Product Z', '9.99', '100', 'Low Stock'],
-        ['D012', 'Product W', '19.99', '25', 'Out of Stock'],
-        ['E345', 'Product V', '15.99', '75', 'In Stock']
-    ])
-    
+    df_no_header = pd.DataFrame(
+        [
+            # First row is clearly data, not a header
+            ["A123", "Product X", "12.99", "50", "In Stock"],
+            ["B456", "Product Y", "24.99", "30", "In Stock"],
+            ["C789", "Product Z", "9.99", "100", "Low Stock"],
+            ["D012", "Product W", "19.99", "25", "Out of Stock"],
+            ["E345", "Product V", "15.99", "75", "In Stock"],
+        ]
+    )
+
     # In a real scenario, the CSV loader would provide the first row as potential headers
-    initial_state = GraphState({
-        'raw_dataframe': df_no_header,
-        'potential_header': df_no_header.iloc[0].tolist(),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": df_no_header,
+            "potential_header": df_no_header.iloc[0].tolist(),
+            "error_messages": [],
+        }
+    )
+
     # Call the actual detection function
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Verify that the function executed without errors
-    assert 'has_header_heuristic' in result_state
-    assert 'error_messages' in result_state
-    assert result_state['error_messages'] == []
-    
+    assert "has_header_heuristic" in result_state
+    assert "error_messages" in result_state
+    assert result_state["error_messages"] == []
+
     # Note: We're not asserting the actual value of has_header_heuristic
     # because the current implementation might detect this as a header
     # In a real-world application, this would be followed by manual verification
     # or additional heuristics to improve accuracy
-    
+
     # Document the current behavior for reference
     print(f"Current heuristic detection result: {result_state['has_header_heuristic']}")
     # This output helps us understand the current behavior without failing the test
+
 
 @pytest.mark.unit
 def test_detect_header_node_no_dataframe(runnable_config):
     """Test that the detect_header_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'has_header_heuristic' not in result_state
-    assert 'detected_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot detect header" in result_state['error_messages'][0]
+    assert "has_header_heuristic" not in result_state
+    assert "detected_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot detect header" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/test_main.py
+++ b/Tabular_to_Neo4j/tests/test_main.py
@@ -11,44 +11,59 @@ from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 from Tabular_to_Neo4j.main import create_graph, run_analysis
 
+
 @pytest.mark.integration
-def test_graph_components_integration(sample_dataframe, runnable_config, mock_llm_response):
+def test_graph_components_integration(
+    sample_dataframe, runnable_config, mock_llm_response
+):
     """Test the integration of graph components directly."""
     # Create the graph
     graph = create_graph()
-    
+
     # Create an initial state with the sample data
     initial_state = {
-        'raw_dataframe': sample_dataframe,
-        'processed_dataframe': sample_dataframe,
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'error_messages': []
+        "raw_dataframe": sample_dataframe,
+        "processed_dataframe": sample_dataframe,
+        "has_header": True,
+        "detected_header": ["id", "name", "age", "email", "city"],
+        "final_header": ["id", "name", "age", "email", "city"],
+        "error_messages": [],
     }
-    
+
     # Test that the graph has the expected nodes
     expected_nodes = [
-        'load_csv', 'detect_header', 'infer_header', 'validate_header',
-        'detect_header_language', 'translate_header', 'apply_header',
-        'analyze_columns', 'semantic_analysis', 'classify_entities_properties',
-        'reconcile_entity_property', 'map_properties_to_entities',
-        'infer_entity_relationships', 'generate_cypher_templates',
-        'synthesize_final_schema'
+        "load_csv",
+        "detect_header",
+        "infer_header",
+        "validate_header",
+        "detect_header_language",
+        "translate_header",
+        "apply_header",
+        "analyze_columns",
+        "semantic_analysis",
+        "classify_entities_properties",
+        "reconcile_entity_property",
+        "map_properties_to_entities",
+        "infer_entity_relationships",
+        "generate_cypher_templates",
+        "synthesize_final_schema",
     ]
-    
+
     for node in expected_nodes:
         assert node in graph.nodes, f"Node {node} not found in graph"
-    
+
     # Test that the graph has edges connecting the nodes
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Verify that the graph is properly connected
     # The first node should be 'load_csv'
-    assert 'load_csv' in graph.nodes, "load_csv node not found"
-    
+    assert "load_csv" in graph.nodes, "load_csv node not found"
+
     # The last node should be 'synthesize_final_schema'
-    assert 'synthesize_final_schema' in graph.nodes, "synthesize_final_schema node not found"
+    assert (
+        "synthesize_final_schema" in graph.nodes
+    ), "synthesize_final_schema node not found"
+
 
 @pytest.mark.integration
 def test_node_execution_mock(sample_dataframe, runnable_config):
@@ -56,141 +71,162 @@ def test_node_execution_mock(sample_dataframe, runnable_config):
     # Import the necessary modules
     from unittest.mock import patch, MagicMock
     from Tabular_to_Neo4j.app_state import GraphState
-    
+
     # Create a mock state with test data
-    initial_state = GraphState({
-        'csv_file_path': '/app/Tabular_to_Neo4j/tests/test_data/sample.csv',
-        'raw_dataframe': sample_dataframe,
-        'processed_dataframe': sample_dataframe,
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'column_analytics': {
-            'id': {'data_type': 'numeric', 'unique_values': 5},
-            'name': {'data_type': 'string', 'unique_values': 5},
-            'age': {'data_type': 'numeric', 'unique_values': 5},
-            'email': {'data_type': 'string', 'unique_values': 5},
-            'city': {'data_type': 'string', 'unique_values': 5}
-        },
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "csv_file_path": "/app/Tabular_to_Neo4j/tests/test_data/sample.csv",
+            "raw_dataframe": sample_dataframe,
+            "processed_dataframe": sample_dataframe,
+            "has_header": True,
+            "detected_header": ["id", "name", "age", "email", "city"],
+            "final_header": ["id", "name", "age", "email", "city"],
+            "column_analytics": {
+                "id": {"data_type": "numeric", "unique_values": 5},
+                "name": {"data_type": "string", "unique_values": 5},
+                "age": {"data_type": "numeric", "unique_values": 5},
+                "email": {"data_type": "string", "unique_values": 5},
+                "city": {"data_type": "string", "unique_values": 5},
+            },
+            "error_messages": [],
+        }
+    )
+
     # Create mock LLM response data
     mock_semantic_analysis_result = {
-        'column_semantics': {
-            'id': {'type': 'identifier', 'description': 'Unique identifier'},
-            'name': {'type': 'personal_name', 'description': 'Full name'},
-            'age': {'type': 'numeric_age', 'description': 'Age in years'},
-            'email': {'type': 'email_address', 'description': 'Contact email'},
-            'city': {'type': 'location', 'description': 'City of residence'}
+        "column_semantics": {
+            "id": {"type": "identifier", "description": "Unique identifier"},
+            "name": {"type": "personal_name", "description": "Full name"},
+            "age": {"type": "numeric_age", "description": "Age in years"},
+            "email": {"type": "email_address", "description": "Contact email"},
+            "city": {"type": "location", "description": "City of residence"},
         }
     }
-    
+
     mock_entity_classification_result = {
-        'entities': ['Person'],
-        'properties': ['id', 'name', 'age', 'email', 'city'],
-        'classification': {
-            'id': 'property', 'name': 'property', 'age': 'property',
-            'email': 'property', 'city': 'property'
-        }
-    }
-    
-    mock_entity_reconciliation_result = {
-        'consensus_classification': {
-            'primary_entity': 'Person',
-            'columns': {
-                'id': 'property', 'name': 'property', 'age': 'property',
-                'email': 'property', 'city': 'property'
-            }
-        }
-    }
-    
-    mock_property_mapping_result = {
-        'property_entity_mapping': {
-            'Person': ['id', 'name', 'age', 'email', 'city']
+        "entities": ["Person"],
+        "properties": ["id", "name", "age", "email", "city"],
+        "classification": {
+            "id": "property",
+            "name": "property",
+            "age": "property",
+            "email": "property",
+            "city": "property",
         },
-        'property_types': {
-            'id': 'String', 'name': 'String', 'age': 'Integer',
-            'email': 'String', 'city': 'String'
-        }
     }
-    
-    mock_relationship_inference_result = {
-        'entity_relationships': []
-    }
-    
-    mock_cypher_generation_result = {
-        'cypher_templates': [
-            'CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})'
-        ],
-        'constraints_and_indexes': [
-            'CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'
-        ]
-    }
-    
-    mock_schema_finalization_result = {
-        'final_schema': {
-            'primary_entity_label': 'Person',
-            'columns_classification': {
-                'id': {'entity': 'Person', 'type': 'String', 'is_key': True},
-                'name': {'entity': 'Person', 'type': 'String', 'is_key': False},
-                'age': {'entity': 'Person', 'type': 'Integer', 'is_key': False},
-                'email': {'entity': 'Person', 'type': 'String', 'is_key': False},
-                'city': {'entity': 'Person', 'type': 'String', 'is_key': False}
+
+    mock_entity_reconciliation_result = {
+        "consensus_classification": {
+            "primary_entity": "Person",
+            "columns": {
+                "id": "property",
+                "name": "property",
+                "age": "property",
+                "email": "property",
+                "city": "property",
             },
-            'relationships': [],
-            'cypher_templates': [
-                'CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})'
-            ],
-            'constraints_and_indexes': [
-                'CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'
-            ]
         }
     }
-    
+
+    mock_property_mapping_result = {
+        "property_entity_mapping": {"Person": ["id", "name", "age", "email", "city"]},
+        "property_types": {
+            "id": "String",
+            "name": "String",
+            "age": "Integer",
+            "email": "String",
+            "city": "String",
+        },
+    }
+
+    mock_relationship_inference_result = {"entity_relationships": []}
+
+    mock_cypher_generation_result = {
+        "cypher_templates": [
+            "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
+        ],
+        "constraints_and_indexes": [
+            "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+        ],
+    }
+
+    mock_schema_finalization_result = {
+        "final_schema": {
+            "primary_entity_label": "Person",
+            "columns_classification": {
+                "id": {"entity": "Person", "type": "String", "is_key": True},
+                "name": {"entity": "Person", "type": "String", "is_key": False},
+                "age": {"entity": "Person", "type": "Integer", "is_key": False},
+                "email": {"entity": "Person", "type": "String", "is_key": False},
+                "city": {"entity": "Person", "type": "String", "is_key": False},
+            },
+            "relationships": [],
+            "cypher_templates": [
+                "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
+            ],
+            "constraints_and_indexes": [
+                "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+            ],
+        }
+    }
+
     # Test that we can create a graph
     graph = create_graph()
     assert graph is not None
-    
+
     # Test that the graph has the expected nodes
     expected_nodes = [
-        'load_csv', 'detect_header', 'infer_header', 'validate_header',
-        'detect_header_language', 'translate_header', 'apply_header',
-        'analyze_columns', 'semantic_analysis', 'classify_entities_properties',
-        'reconcile_entity_property', 'map_properties_to_entities',
-        'infer_entity_relationships', 'generate_cypher_templates',
-        'synthesize_final_schema'
+        "load_csv",
+        "detect_header",
+        "infer_header",
+        "validate_header",
+        "detect_header_language",
+        "translate_header",
+        "apply_header",
+        "analyze_columns",
+        "semantic_analysis",
+        "classify_entities_properties",
+        "reconcile_entity_property",
+        "map_properties_to_entities",
+        "infer_entity_relationships",
+        "generate_cypher_templates",
+        "synthesize_final_schema",
     ]
-    
+
     for node in expected_nodes:
         assert node in graph.nodes, f"Node {node} not found in graph"
-    
+
     # Test that the graph has edges connecting the nodes
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Instead of testing the actual node execution, let's just test the graph structure
     # This avoids issues with missing prompt templates and other dependencies
-    
+
     # Test the graph connectivity
     # Check that the graph has edges
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Check that the expected nodes are in the graph
-    assert 'load_csv' in graph.nodes, "load_csv node not found"
-    assert 'detect_header' in graph.nodes, "detect_header node not found"
-    assert 'infer_header' in graph.nodes, "infer_header node not found"
-    assert 'validate_header' in graph.nodes, "validate_header node not found"
-    assert 'semantic_analysis' in graph.nodes, "semantic_analysis node not found"
-    assert 'classify_entities_properties' in graph.nodes, "classify_entities_properties node not found"
-    assert 'synthesize_final_schema' in graph.nodes, "synthesize_final_schema node not found"
-    
+    assert "load_csv" in graph.nodes, "load_csv node not found"
+    assert "detect_header" in graph.nodes, "detect_header node not found"
+    assert "infer_header" in graph.nodes, "infer_header node not found"
+    assert "validate_header" in graph.nodes, "validate_header node not found"
+    assert "semantic_analysis" in graph.nodes, "semantic_analysis node not found"
+    assert (
+        "classify_entities_properties" in graph.nodes
+    ), "classify_entities_properties node not found"
+    assert (
+        "synthesize_final_schema" in graph.nodes
+    ), "synthesize_final_schema node not found"
+
     # Verify the graph has the expected structure
     # Check that nodes are connected in a logical sequence
     # We can't directly check edge connections, but we can verify the graph has edges
     assert graph.edges is not None, "Graph has no edges defined"
     assert len(graph.edges) > 10, "Graph has too few edges"
-    
+
     # The graph structure tests are complete
+
 
 @pytest.mark.unit
 def test_create_graph():
@@ -198,11 +234,10 @@ def test_create_graph():
     # Create the graph
     graph = create_graph()
 
-    
     # Check that the graph has nodes
-    assert hasattr(graph, 'nodes')
+    assert hasattr(graph, "nodes")
     assert len(graph.nodes) > 0
-    
+
     # Check that the graph has edges
-    assert hasattr(graph, 'edges')
+    assert hasattr(graph, "edges")
     assert len(graph.edges) > 0


### PR DESCRIPTION
## Summary
- replace TypedDict `GraphState` with dataclass that behaves like a mapping
- adjust tests to instantiate state with `GraphState.from_dict`

## Testing
- `black Tabular_to_Neo4j/app_state.py Tabular_to_Neo4j/tests`
- `flake8 Tabular_to_Neo4j/app_state.py Tabular_to_Neo4j/tests` *(fails: command not found)*
- `pytest -q` *(fails: missing pandas/langchain_core)*

------
https://chatgpt.com/codex/tasks/task_e_68475cd453bc832fb622727ef8e24cc1