### PR TITLE
Encapsulate state with dataclass

### DIFF
--- a/Tabular_to_Neo4j/README.md
+++ b/Tabular_to_Neo4j/README.md
@@ -97,7 +97,7 @@ LLM_CONFIGS = {
 Run this script to verify your LMStudio connection:
 
 ```python
-from Tabular_to_Neo4j.utils.llm_manager import get_lmstudio_models, list_loaded_models
+from Tabular_to_Neo4j.utils.llm_api import get_lmstudio_models, list_loaded_models
 
 # Get available models from LMStudio
 models = get_lmstudio_models()

--- a/Tabular_to_Neo4j/main.py
+++ b/Tabular_to_Neo4j/main.py
@@ -21,6 +21,7 @@ logger = get_logger(__name__)
 # Load environment variables from .env file if present
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
     logger.info("Loaded environment variables from .env file")
 except ImportError:
@@ -35,57 +36,54 @@ from langgraph.graph import StateGraph, END
 from Tabular_to_Neo4j.app_state import GraphState
 
 # Import input nodes
-from Tabular_to_Neo4j.nodes.input import (
-    load_csv_node,
-    detect_header_heuristic_node
-)
+from Tabular_to_Neo4j.nodes.input import load_csv_node, detect_header_heuristic_node
 
 # Import header processing nodes
 from Tabular_to_Neo4j.nodes.header_processing import (
-    infer_header_llm_node, 
-    validate_header_llm_node, 
+    infer_header_llm_node,
+    validate_header_llm_node,
     detect_header_language_node,
-    translate_header_llm_node, 
-    apply_header_node
+    translate_header_llm_node,
+    apply_header_node,
 )
 
 # Import analysis nodes
-from Tabular_to_Neo4j.nodes.analysis import (
-    perform_column_analytics_node
-)
+from Tabular_to_Neo4j.nodes.analysis import perform_column_analytics_node
 
 # Import entity inference nodes
 from Tabular_to_Neo4j.nodes.entity_inference import (
     classify_entities_properties_node,
     reconcile_entity_property_node,
     map_properties_to_entities_node,
-    infer_entity_relationships_node
+    infer_entity_relationships_node,
 )
 
 # Import database schema generation nodes
-from Tabular_to_Neo4j.nodes.db_schema import (
-    generate_cypher_templates_node
-)
+from Tabular_to_Neo4j.nodes.db_schema import generate_cypher_templates_node
 
 # Import output saver
-from Tabular_to_Neo4j.utils.output_saver import initialize_output_saver, get_output_saver
+from Tabular_to_Neo4j.utils.output_saver import (
+    initialize_output_saver,
+    get_output_saver,
+)
 
 # Get a logger for this module
 logger = get_logger(__name__)
 
+
 def create_graph() -> StateGraph:
     """
     Create the LangGraph for CSV analysis and Neo4j schema inference.
-    
+
     Returns:
         StateGraph instance
     """
     # Create the graph with the GraphState type
     graph = StateGraph(GraphState)
-    
+
     # Get the output saver
     output_saver = get_output_saver()
-    
+
     # Define node order for output file naming
     node_order = {
         "load_csv": 1,
@@ -100,68 +98,152 @@ def create_graph() -> StateGraph:
         "reconcile_entity_property": 10,
         "map_properties_to_entities": 11,
         "infer_entity_relationships": 12,
-        "generate_cypher_templates": 13
+        "generate_cypher_templates": 13,
     }
-    
+
     # Add nodes to the graph
 
     # Input nodes
-    graph.add_node("load_csv", wrap_node_with_output_saving("load_csv", load_csv_node, node_order["load_csv"]))
-    graph.add_node("detect_header", wrap_node_with_output_saving("detect_header", detect_header_heuristic_node, node_order["detect_header"]))
-    
+    graph.add_node(
+        "load_csv",
+        wrap_node_with_output_saving("load_csv", load_csv_node, node_order["load_csv"]),
+    )
+    graph.add_node(
+        "detect_header",
+        wrap_node_with_output_saving(
+            "detect_header", detect_header_heuristic_node, node_order["detect_header"]
+        ),
+    )
+
     # Header processing nodes
-    graph.add_node("infer_header", wrap_node_with_output_saving("infer_header", infer_header_llm_node, node_order["infer_header"]))
-    graph.add_node("validate_header", wrap_node_with_output_saving("validate_header", validate_header_llm_node, node_order["validate_header"]))
-    graph.add_node("detect_header_language", wrap_node_with_output_saving("detect_header_language", detect_header_language_node, node_order["detect_header_language"]))
-    graph.add_node("translate_header", wrap_node_with_output_saving("translate_header", translate_header_llm_node, node_order["translate_header"]))
-    graph.add_node("apply_header", wrap_node_with_output_saving("apply_header", apply_header_node, node_order["apply_header"]))
-    
+    graph.add_node(
+        "infer_header",
+        wrap_node_with_output_saving(
+            "infer_header", infer_header_llm_node, node_order["infer_header"]
+        ),
+    )
+    graph.add_node(
+        "validate_header",
+        wrap_node_with_output_saving(
+            "validate_header", validate_header_llm_node, node_order["validate_header"]
+        ),
+    )
+    graph.add_node(
+        "detect_header_language",
+        wrap_node_with_output_saving(
+            "detect_header_language",
+            detect_header_language_node,
+            node_order["detect_header_language"],
+        ),
+    )
+    graph.add_node(
+        "translate_header",
+        wrap_node_with_output_saving(
+            "translate_header",
+            translate_header_llm_node,
+            node_order["translate_header"],
+        ),
+    )
+    graph.add_node(
+        "apply_header",
+        wrap_node_with_output_saving(
+            "apply_header", apply_header_node, node_order["apply_header"]
+        ),
+    )
+
     # Analysis nodes
-    graph.add_node("analyze_columns", wrap_node_with_output_saving("analyze_columns", perform_column_analytics_node, node_order["analyze_columns"]))
-    
-    
+    graph.add_node(
+        "analyze_columns",
+        wrap_node_with_output_saving(
+            "analyze_columns",
+            perform_column_analytics_node,
+            node_order["analyze_columns"],
+        ),
+    )
+
     # Entity and Relationship Inference
-    graph.add_node("classify_entities_properties", wrap_node_with_output_saving("classify_entities_properties", classify_entities_properties_node, node_order["classify_entities_properties"]))
-    graph.add_node("reconcile_entity_property", wrap_node_with_output_saving("reconcile_entity_property", reconcile_entity_property_node, node_order["reconcile_entity_property"]))
-    graph.add_node("map_properties_to_entities", wrap_node_with_output_saving("map_properties_to_entities", map_properties_to_entities_node, node_order["map_properties_to_entities"]))
-    graph.add_node("infer_entity_relationships", wrap_node_with_output_saving("infer_entity_relationships", infer_entity_relationships_node, node_order["infer_entity_relationships"]))
-    
+    graph.add_node(
+        "classify_entities_properties",
+        wrap_node_with_output_saving(
+            "classify_entities_properties",
+            classify_entities_properties_node,
+            node_order["classify_entities_properties"],
+        ),
+    )
+    graph.add_node(
+        "reconcile_entity_property",
+        wrap_node_with_output_saving(
+            "reconcile_entity_property",
+            reconcile_entity_property_node,
+            node_order["reconcile_entity_property"],
+        ),
+    )
+    graph.add_node(
+        "map_properties_to_entities",
+        wrap_node_with_output_saving(
+            "map_properties_to_entities",
+            map_properties_to_entities_node,
+            node_order["map_properties_to_entities"],
+        ),
+    )
+    graph.add_node(
+        "infer_entity_relationships",
+        wrap_node_with_output_saving(
+            "infer_entity_relationships",
+            infer_entity_relationships_node,
+            node_order["infer_entity_relationships"],
+        ),
+    )
+
     # Database Schema Generation
-    graph.add_node("generate_cypher_templates", wrap_node_with_output_saving("generate_cypher_templates", generate_cypher_templates_node, node_order["generate_cypher_templates"]))
-    
+    graph.add_node(
+        "generate_cypher_templates",
+        wrap_node_with_output_saving(
+            "generate_cypher_templates",
+            generate_cypher_templates_node,
+            node_order["generate_cypher_templates"],
+        ),
+    )
+
     # Define the edges
     # Start with loading the CSV
     graph.add_edge("load_csv", "detect_header")
-    
+
     # Conditional edge from detect_header based on has_header_heuristic
     graph.add_conditional_edges(
         "detect_header",
-        lambda state: "has_header" if state.get("has_header_heuristic", False) else "no_header",
+        lambda state: (
+            "has_header" if state.get("has_header_heuristic", False) else "no_header"
+        ),
         {
             "has_header": "validate_header",  # If header detected, skip inference
-            "no_header": "infer_header"       # If no header detected, infer headers
-        }
+            "no_header": "infer_header",  # If no header detected, infer headers
+        },
     )
-    
+
     # Continue the flow from infer_header to validate_header
     graph.add_edge("infer_header", "validate_header")
-    
+
     # Add language detection after header validation
     graph.add_edge("validate_header", "detect_header_language")
-    
+
     # Conditional edge from detect_header_language based on is_header_in_target_language
     graph.add_conditional_edges(
         "detect_header_language",
-        lambda state: "same_language" if state.get("is_header_in_target_language", False) else "different_language",
+        lambda state: (
+            "same_language"
+            if state.get("is_header_in_target_language", False)
+            else "different_language"
+        ),
         {
-            "same_language": "apply_header",       # If header already in target language, skip translation
-            "different_language": "translate_header" # If header in different language, translate it
-        }
+            "same_language": "apply_header",  # If header already in target language, skip translation
+            "different_language": "translate_header",  # If header in different language, translate it
+        },
     )
-    
+
     # Continue with header translation (if needed) and application
     graph.add_edge("translate_header", "apply_header")
-    
+
     # Column analysis
     graph.add_edge("apply_header", "analyze_columns")
     # Schema synthesis pipeline
@@ -170,134 +252,152 @@ def create_graph() -> StateGraph:
     graph.add_edge("reconcile_entity_property", "map_properties_to_entities")
     graph.add_edge("map_properties_to_entities", "infer_entity_relationships")
     graph.add_edge("infer_entity_relationships", "generate_cypher_templates")
-    
+
     # End the graph after cypher template generation
     graph.add_edge("generate_cypher_templates", END)
-    
+
     # Set the entry point
     graph.set_entry_point("load_csv")
-    
+
     return graph
+
 
 def format_schema_output(schema: Dict[str, Any]) -> str:
     """
     Format the inferred Neo4j schema for human-readable output.
-    
+
     Args:
         schema: The inferred Neo4j schema
-        
+
     Returns:
         Formatted string representation
     """
     output = []
-    
+
     # Primary entity
     output.append(f"PRIMARY ENTITY: :{schema['primary_entity_label']}")
     output.append("")
-    
+
     # Group columns by role
     columns_by_role = {}
-    for col in schema.get('columns_classification', []):
-        role = col.get('role', 'UNKNOWN')
+    for col in schema.get("columns_classification", []):
+        role = col.get("role", "UNKNOWN")
         if role not in columns_by_role:
             columns_by_role[role] = []
         columns_by_role[role].append(col)
-    
+
     # Format primary entity identifiers
-    if 'PRIMARY_ENTITY_IDENTIFIER' in columns_by_role:
+    if "PRIMARY_ENTITY_IDENTIFIER" in columns_by_role:
         output.append("PRIMARY ENTITY IDENTIFIERS:")
-        for col in columns_by_role['PRIMARY_ENTITY_IDENTIFIER']:
-            output.append(f"  - {col['original_column_name']} → .{col['neo4j_property_key']}")
+        for col in columns_by_role["PRIMARY_ENTITY_IDENTIFIER"]:
+            output.append(
+                f"  - {col['original_column_name']} → .{col['neo4j_property_key']}"
+            )
         output.append("")
-    
+
     # Format primary entity properties
-    if 'PRIMARY_ENTITY_PROPERTY' in columns_by_role:
+    if "PRIMARY_ENTITY_PROPERTY" in columns_by_role:
         output.append("PRIMARY ENTITY PROPERTIES:")
-        for col in columns_by_role['PRIMARY_ENTITY_PROPERTY']:
-            note = f" (Note: {col['note']})" if 'note' in col else ""
-            output.append(f"  - {col['original_column_name']} → .{col['neo4j_property_key']}{note}")
+        for col in columns_by_role["PRIMARY_ENTITY_PROPERTY"]:
+            note = f" (Note: {col['note']})" if "note" in col else ""
+            output.append(
+                f"  - {col['original_column_name']} → .{col['neo4j_property_key']}{note}"
+            )
         output.append("")
-    
+
     # Format new node types
-    if 'NEW_NODE_TYPE_VALUES' in columns_by_role:
+    if "NEW_NODE_TYPE_VALUES" in columns_by_role:
         output.append("NEW NODE TYPES:")
-        for col in columns_by_role['NEW_NODE_TYPE_VALUES']:
-            output.append(f"  - {col['original_column_name']} → :{col['new_node_label']} nodes")
-            output.append(f"    Relationship: (:{schema['primary_entity_label']})-[:{col['relationship_to_primary']}]->(:{col['new_node_label']})")
-            
+        for col in columns_by_role["NEW_NODE_TYPE_VALUES"]:
+            output.append(
+                f"  - {col['original_column_name']} → :{col['new_node_label']} nodes"
+            )
+            output.append(
+                f"    Relationship: (:{schema['primary_entity_label']})-[:{col['relationship_to_primary']}]->(:{col['new_node_label']})"
+            )
+
             # Add associated properties for this node type
-            if 'NEW_NODE_PROPERTY' in columns_by_role:
+            if "NEW_NODE_PROPERTY" in columns_by_role:
                 associated_props = [
-                    prop for prop in columns_by_role['NEW_NODE_PROPERTY']
-                    if prop.get('associated_new_node_label') == col['new_node_label']
+                    prop
+                    for prop in columns_by_role["NEW_NODE_PROPERTY"]
+                    if prop.get("associated_new_node_label") == col["new_node_label"]
                 ]
                 if associated_props:
                     output.append(f"    Properties:")
                     for prop in associated_props:
-                        output.append(f"      - {prop['original_column_name']} → .{prop['neo4j_property_key']}")
-            
+                        output.append(
+                            f"      - {prop['original_column_name']} → .{prop['neo4j_property_key']}"
+                        )
+
             output.append("")
-    
+
     # Format relationship properties
-    if 'RELATIONSHIP_PROPERTY' in columns_by_role:
+    if "RELATIONSHIP_PROPERTY" in columns_by_role:
         output.append("RELATIONSHIP PROPERTIES:")
-        for col in columns_by_role['RELATIONSHIP_PROPERTY']:
-            rel = col.get('associated_relationship', 'UNKNOWN')
-            source = col.get('source_node_label', schema['primary_entity_label'])
-            target = col.get('target_node_label', 'UNKNOWN')
-            output.append(f"  - {col['original_column_name']} → property on relationship (:{source})-[:{rel}]->(:{target})")
+        for col in columns_by_role["RELATIONSHIP_PROPERTY"]:
+            rel = col.get("associated_relationship", "UNKNOWN")
+            source = col.get("source_node_label", schema["primary_entity_label"])
+            target = col.get("target_node_label", "UNKNOWN")
+            output.append(
+                f"  - {col['original_column_name']} → property on relationship (:{source})-[:{rel}]->(:{target})"
+            )
         output.append("")
-    
+
     return "\n".join(output)
 
-def run_analysis(csv_file_path: str, output_file: str = None, verbose: bool = False, 
-                save_node_outputs: bool = False, output_dir: str = "samples") -> Dict[str, Any]:
+
+def run_analysis(
+    csv_file_path: str,
+    output_file: str = None,
+    verbose: bool = False,
+    save_node_outputs: bool = False,
+    output_dir: str = "samples",
+) -> Dict[str, Any]:
     """
     Run the CSV analysis and Neo4j schema inference.
-    
+
     Args:
         csv_file_path: Path to the CSV file
         output_file: Optional path to save the results
         verbose: Whether to print verbose output
-        
+
     Returns:
         The final graph state
     """
     # Import and reset the prompt sample directory to ensure all samples from this run
     # are stored in the same directory
-    from Tabular_to_Neo4j.utils.llm_manager import reset_prompt_sample_directory
+    from Tabular_to_Neo4j.utils.prompt_utils import reset_prompt_sample_directory
+
     reset_prompt_sample_directory()
-    
+
     # Log analysis start with file details
     logger.info(f"Starting analysis of CSV file: {csv_file_path}")
     if not os.path.exists(csv_file_path):
         logger.error(f"CSV file not found: {csv_file_path}")
         raise FileNotFoundError(f"CSV file not found: {csv_file_path}")
-    
+
     # Log file size and basic info
     file_size = os.path.getsize(csv_file_path) / 1024  # KB
     logger.info(f"File size: {file_size:.2f} KB")
-    
+
     # Initialize output saver if requested
     if save_node_outputs:
         logger.info(f"Initializing output saver with directory: {output_dir}")
         initialize_output_saver(output_dir)
-    
+
     # Create the graph
     logger.debug("Creating state graph")
     graph = create_graph()
-    
+
     # Compile the graph
     logger.debug("Compiling state graph")
     app = graph.compile()
-    
+
     # Set up the initial state
     logger.debug("Initializing state")
-    initial_state = GraphState(
-        csv_file_path=csv_file_path,
-        error_messages=[]
-    )
-    
+    initial_state = GraphState(csv_file_path=csv_file_path, error_messages=[])
+
     # Run the graph
     logger.info(f"Executing analysis pipeline")
     start_time = time.time()
@@ -308,133 +408,158 @@ def run_analysis(csv_file_path: str, output_file: str = None, verbose: bool = Fa
     except Exception as e:
         logger.error(f"Analysis failed: {str(e)}", exc_info=True)
         raise
-    
+
     # Log the results
-    if final_state.get('error_messages'):
-        error_count = len(final_state.get('error_messages', []))
+    if final_state.get("error_messages"):
+        error_count = len(final_state.get("error_messages", []))
         logger.warning(f"Analysis completed with {error_count} errors/warnings")
-        for i, error in enumerate(final_state.get('error_messages', [])):
+        for i, error in enumerate(final_state.get("error_messages", [])):
             logger.warning(f"Error/Warning {i+1}: {error}")
     else:
         logger.info("Analysis completed successfully with no errors")
-    
+
     # Log cypher template information
-    if final_state.get('cypher_query_templates'):
-        templates = final_state['cypher_query_templates']
-        entity_count = len(templates.get('entity_creation_queries', []))
-        relationship_count = len(templates.get('relationship_queries', []))
-        example_count = len(templates.get('example_queries', []))
-        logger.info(f"Generated {entity_count} entity creation queries, {relationship_count} relationship queries, and {example_count} example queries")
+    if final_state.get("cypher_query_templates"):
+        templates = final_state["cypher_query_templates"]
+        entity_count = len(templates.get("entity_creation_queries", []))
+        relationship_count = len(templates.get("relationship_queries", []))
+        example_count = len(templates.get("example_queries", []))
+        logger.info(
+            f"Generated {entity_count} entity creation queries, {relationship_count} relationship queries, and {example_count} example queries"
+        )
     else:
         logger.warning("No Cypher templates were generated")
-    
+
     # Save results to file if requested
     if output_file:
         try:
             logger.info(f"Saving results to {output_file}")
-            with open(output_file, 'w') as f:
-                if final_state.get('cypher_query_templates'):
-                    templates = final_state['cypher_query_templates']
+            with open(output_file, "w") as f:
+                if final_state.get("cypher_query_templates"):
+                    templates = final_state["cypher_query_templates"]
                     f.write("ENTITY CREATION QUERIES:\n")
-                    for i, query in enumerate(templates.get('entity_creation_queries', [])):
+                    for i, query in enumerate(
+                        templates.get("entity_creation_queries", [])
+                    ):
                         f.write(f"\nQuery {i+1}:\n{query.get('query', '')}\n")
-                    
+
                     f.write("\nRELATIONSHIP QUERIES:\n")
-                    for i, query in enumerate(templates.get('relationship_queries', [])):
+                    for i, query in enumerate(
+                        templates.get("relationship_queries", [])
+                    ):
                         f.write(f"\nQuery {i+1}:\n{query.get('query', '')}\n")
-                    
+
                     f.write("\nEXAMPLE QUERIES:\n")
-                    for i, query in enumerate(templates.get('example_queries', [])):
+                    for i, query in enumerate(templates.get("example_queries", [])):
                         f.write(f"\nQuery {i+1}:\n{query.get('query', '')}\n")
                 else:
                     f.write("No Cypher templates generated.\n")
-                    
-                if final_state.get('error_messages'):
+
+                if final_state.get("error_messages"):
                     f.write("\nErrors/Warnings:\n")
-                    for error in final_state.get('error_messages', []):
+                    for error in final_state.get("error_messages", []):
                         f.write(f"  - {error}\n")
             logger.info(f"Results saved to {output_file}")
         except Exception as e:
             logger.error(f"Failed to save results to {output_file}: {str(e)}")
-    
+
     # Print the results if verbose
     if verbose:
         logger.info("Displaying analysis results")
-        
+
         # Print any errors
-        if final_state.get('error_messages'):
+        if final_state.get("error_messages"):
             print("\nErrors/Warnings encountered during analysis:")
-            for error in final_state.get('error_messages', []):
+            for error in final_state.get("error_messages", []):
                 print(f"  - {error}")
-        
+
         # Print the generated Cypher templates
-        if final_state.get('cypher_query_templates'):
-            templates = final_state['cypher_query_templates']
+        if final_state.get("cypher_query_templates"):
+            templates = final_state["cypher_query_templates"]
             print("\nGenerated Cypher Templates:")
-            
+
             print("\nENTITY CREATION QUERIES:")
-            for i, query in enumerate(templates.get('entity_creation_queries', [])):
+            for i, query in enumerate(templates.get("entity_creation_queries", [])):
                 print(f"\nQuery {i+1}:")
-                print(query.get('query', ''))
-            
+                print(query.get("query", ""))
+
             print("\nRELATIONSHIP QUERIES:")
-            for i, query in enumerate(templates.get('relationship_queries', [])):
+            for i, query in enumerate(templates.get("relationship_queries", [])):
                 print(f"\nQuery {i+1}:")
-                print(query.get('query', ''))
-            
+                print(query.get("query", ""))
+
             print("\nEXAMPLE QUERIES:")
-            for i, query in enumerate(templates.get('example_queries', [])):
+            for i, query in enumerate(templates.get("example_queries", [])):
                 print(f"\nQuery {i+1}:")
-                print(query.get('query', ''))
-    
+                print(query.get("query", ""))
+
     return final_state
+
 
 def main():
     """
     Main entry point for the command-line interface.
     """
-    parser = argparse.ArgumentParser(description='Run Tabular to Neo4j converter.')
-    parser.add_argument('csv_file', help='Path to the CSV file to analyze')
-    parser.add_argument('--output', '-o', help='Path to save the results')
-    parser.add_argument('--verbose', '-v', action='store_true', help='Print verbose output')
-    parser.add_argument('--save-node-outputs', '-s', action='store_true', 
-                        help='Save the output of each node to files')
-    parser.add_argument('--output-dir', '-d', default="samples",
-                        help='Directory to save node outputs to (default: samples)')
-    
+    parser = argparse.ArgumentParser(description="Run Tabular to Neo4j converter.")
+    parser.add_argument("csv_file", help="Path to the CSV file to analyze")
+    parser.add_argument("--output", "-o", help="Path to save the results")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print verbose output"
+    )
+    parser.add_argument(
+        "--save-node-outputs",
+        "-s",
+        action="store_true",
+        help="Save the output of each node to files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        "-d",
+        default="samples",
+        help="Directory to save node outputs to (default: samples)",
+    )
+
     args = parser.parse_args()
-    
+
     try:
-        run_analysis(args.csv_file, args.output, args.verbose, 
-                     args.save_node_outputs, args.output_dir)
+        run_analysis(
+            args.csv_file,
+            args.output,
+            args.verbose,
+            args.save_node_outputs,
+            args.output_dir,
+        )
     except Exception as e:
         print(f"Error: {str(e)}")
         sys.exit(1)
 
+
 def wrap_node_with_output_saving(node_name: str, node_func, node_order: int = 0):
     """
     Wrap a node function with output saving functionality.
-    
+
     Args:
         node_name: Name of the node
         node_func: Node function to wrap
         node_order: Order of the node in the pipeline (for file naming)
-        
+
     Returns:
         Wrapped node function
     """
+
     def wrapped_node(state, config=None):
         # Call the original node function with the config parameter
         result = node_func(state, config) if config is not None else node_func(state)
-        
+
         # Save the output if output saver is initialized
         output_saver = get_output_saver()
         if output_saver:
             output_saver.save_node_output(node_name, result, node_order)
-        
+
         return result
-    
+
     return wrapped_node
+
 
 if __name__ == "__main__":
     main()

--- a/Tabular_to_Neo4j/nodes/db_schema/cypher_generation.py
+++ b/Tabular_to_Neo4j/nodes/db_schema/cypher_generation.py
@@ -8,250 +8,309 @@ import os
 import json
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.config import MAX_SAMPLE_ROWS
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 
 # Configure logging
 logger = get_logger(__name__)
 
-def generate_cypher_templates_node(state: GraphState, config: RunnableConfig) -> GraphState:
+
+def generate_cypher_templates_node(
+    state: GraphState, config: RunnableConfig
+) -> GraphState:
     """
     Generate template Cypher queries for the inferred schema.
     Uses LLM to create Cypher query templates for loading and querying the Neo4j graph model.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with cypher_query_templates
     """
     logger.info("Starting Cypher template generation process")
-    
+
     # Validate required inputs
     missing_inputs = []
-    if state.get('property_entity_mapping') is None:
+    if state.get("property_entity_mapping") is None:
         missing_inputs.append("property_entity_mapping")
-    if state.get('entity_relationships') is None:
+    if state.get("entity_relationships") is None:
         missing_inputs.append("entity_relationships")
-    
+
     if missing_inputs:
         error_msg = f"Cannot generate Cypher templates: missing required data: {', '.join(missing_inputs)}"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     try:
         # Get the property-entity mapping and relationships
-        mapping = state['property_entity_mapping']
-        relationships = state['entity_relationships']
-        
+        mapping = state["property_entity_mapping"]
+        relationships = state["entity_relationships"]
+
         # Extract entity types and their properties
         entities = {}
         for entity_name, item in mapping.items():
-            if item.get('type') == 'entity':
+            if item.get("type") == "entity":
                 # Use the column name as the entity type if entity_type is not specified
-                entity_type = item.get('entity_type', entity_name)
-                
+                entity_type = item.get("entity_type", entity_name)
+
                 # Get properties for this entity
-                properties = item.get('properties', [])
-                
+                properties = item.get("properties", [])
+
                 # Every entity needs a generated UUID as a unique identifier
                 entities[entity_type] = {
-                    'is_primary': item.get('is_primary', True),  # Default to primary if not specified
-                    'properties': properties,
-                    'needs_generated_id': True  # Always generate a unique ID for every entity
+                    "is_primary": item.get(
+                        "is_primary", True
+                    ),  # Default to primary if not specified
+                    "properties": properties,
+                    "needs_generated_id": True,  # Always generate a unique ID for every entity
                 }
-        
-        logger.debug(f"Preparing Cypher templates for {len(entities)} entities and {len(relationships)} relationships")
-        
+
+        logger.debug(
+            f"Preparing Cypher templates for {len(entities)} entities and {len(relationships)} relationships"
+        )
+
         # Get metadata for the CSV file
         metadata = get_metadata_for_state(state)
-        metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-        
+        metadata_text = (
+            format_metadata_for_prompt(metadata)
+            if metadata
+            else "No metadata available."
+        )
+
         # Get sample data from the processed dataframe
         sample_data = ""
-        if state.get('processed_dataframe') is not None:
-            df = state['processed_dataframe']
+        if state.get("processed_dataframe") is not None:
+            df = state["processed_dataframe"]
             if not df.empty:
                 try:
-                    sample_data = df.head(MAX_SAMPLE_ROWS).to_dict(orient='records')
+                    sample_data = df.head(MAX_SAMPLE_ROWS).to_dict(orient="records")
                     sample_data = str(sample_data)  # Convert to string for the prompt
                 except Exception as e:
                     logger.warning(f"Error converting dataframe to dict: {str(e)}")
                     # Fallback to string representation
                     sample_data = df.head(MAX_SAMPLE_ROWS).to_string(index=False)
-        
+
         # Use LLM to generate Cypher templates
         logger.info("Using LLM to generate Cypher templates")
-        
+
         try:
             # Format the prompt for the LLM
-            template_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 
-                                        "prompts", "generate_cypher_templates.txt")
-            
+            template_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+                "prompts",
+                "generate_cypher_templates.txt",
+            )
+
             # Format entities for the prompt
             entities_for_prompt = {}
             for entity_type, entity_info in entities.items():
                 properties_list = []
-                for prop in entity_info.get('properties', []):
-                    if isinstance(prop, dict) and 'column_name' in prop and 'property_key' in prop:
-                        properties_list.append({
-                            'column_name': prop['column_name'],
-                            'property_key': prop['property_key']
-                        })
-                
+                for prop in entity_info.get("properties", []):
+                    if (
+                        isinstance(prop, dict)
+                        and "column_name" in prop
+                        and "property_key" in prop
+                    ):
+                        properties_list.append(
+                            {
+                                "column_name": prop["column_name"],
+                                "property_key": prop["property_key"],
+                            }
+                        )
+
                 entities_for_prompt[entity_type] = {
-                    'is_primary': entity_info.get('is_primary', True),
-                    'properties': properties_list
+                    "is_primary": entity_info.get("is_primary", True),
+                    "properties": properties_list,
                 }
-            
+
             # Format relationships for the prompt
             relationships_for_prompt = []
             for rel in relationships:
-                relationships_for_prompt.append({
-                    'source_entity': rel.get('source_entity'),
-                    'target_entity': rel.get('target_entity'),
-                    'relationship_type': rel.get('relationship_type'),
-                    'confidence': rel.get('confidence', 0.0),
-                    'reasoning': rel.get('reasoning', '')
-                })
-            
+                relationships_for_prompt.append(
+                    {
+                        "source_entity": rel.get("source_entity"),
+                        "target_entity": rel.get("target_entity"),
+                        "relationship_type": rel.get("relationship_type"),
+                        "confidence": rel.get("confidence", 0.0),
+                        "reasoning": rel.get("reasoning", ""),
+                    }
+                )
+
             # Format the prompt with the template
             prompt = format_prompt(
                 template_name="generate_cypher_templates.txt",
                 entities=json.dumps(entities_for_prompt, indent=2),
                 relationships=json.dumps(relationships_for_prompt, indent=2),
                 metadata_text=metadata_text,
-                sample_data=sample_data
+                sample_data=sample_data,
             )
-            
+
             # Call the LLM to generate Cypher templates
-            response = call_llm_with_json_output(prompt, state_name="generate_cypher_templates")
-            
+            response = call_llm_with_json_output(
+                prompt, state_name="generate_cypher_templates"
+            )
+
             # Initialize the query lists if they don't exist in the response
             if not response:
                 response = {}
-            if 'entity_creation_queries' not in response:
-                response['entity_creation_queries'] = []
-            if 'relationship_queries' not in response:
-                response['relationship_queries'] = []
-            if 'example_queries' not in response:
-                response['example_queries'] = []
-            if 'constraint_queries' not in response:
-                response['constraint_queries'] = []
-            
+            if "entity_creation_queries" not in response:
+                response["entity_creation_queries"] = []
+            if "relationship_queries" not in response:
+                response["relationship_queries"] = []
+            if "example_queries" not in response:
+                response["example_queries"] = []
+            if "constraint_queries" not in response:
+                response["constraint_queries"] = []
+
             # Generate rule-based Cypher templates as a fallback
             def generate_rule_based_templates():
                 # Initialize response structure
                 rule_based_response = {
-                    'entity_creation_queries': [],
-                    'relationship_queries': [],
-                    'example_queries': [],
-                    'constraint_queries': []
+                    "entity_creation_queries": [],
+                    "relationship_queries": [],
+                    "example_queries": [],
+                    "constraint_queries": [],
                 }
-                
+
                 # Process each entity to generate Cypher queries
                 for entity_type, entity_info in entities.items():
-                    properties = entity_info.get('properties', [])
-                    
+                    properties = entity_info.get("properties", [])
+
                     # Generate constraint query for entity
-                    constraint_query = f"CREATE CONSTRAINT ON (n:{entity_type}) ASSERT n.id IS UNIQUE;"
-                    rule_based_response['constraint_queries'].append({
-                        "query": constraint_query,
-                        "description": f"Create unique constraint on {entity_type}.id"
-                    })
-                    
+                    constraint_query = (
+                        f"CREATE CONSTRAINT ON (n:{entity_type}) ASSERT n.id IS UNIQUE;"
+                    )
+                    rule_based_response["constraint_queries"].append(
+                        {
+                            "query": constraint_query,
+                            "description": f"Create unique constraint on {entity_type}.id",
+                        }
+                    )
+
                     # Generate entity creation query
                     property_assignments = []
                     for prop in properties:
-                        if isinstance(prop, dict) and 'column_name' in prop and 'property_key' in prop:
-                            column_name = prop['column_name']
-                            property_key = prop['property_key']
-                            property_assignments.append(f"{property_key}: row.{column_name}")
-                    
+                        if (
+                            isinstance(prop, dict)
+                            and "column_name" in prop
+                            and "property_key" in prop
+                        ):
+                            column_name = prop["column_name"]
+                            property_key = prop["property_key"]
+                            property_assignments.append(
+                                f"{property_key}: row.{column_name}"
+                            )
+
                     # Always add a unique ID
                     property_assignments.append("id: randomUUID()")
-                    
+
                     property_assignments_str = ", ".join(property_assignments)
                     entity_query = f"LOAD CSV WITH HEADERS FROM 'file:///data.csv' AS row\nCREATE (n:{entity_type} {{{property_assignments_str}}});"
-                    
-                    rule_based_response['entity_creation_queries'].append({
-                        "query": entity_query,
-                        "description": f"Create {entity_type} nodes from CSV data"
-                    })
-                    
+
+                    rule_based_response["entity_creation_queries"].append(
+                        {
+                            "query": entity_query,
+                            "description": f"Create {entity_type} nodes from CSV data",
+                        }
+                    )
+
                     # Generate example query
                     example_query = f"MATCH (n:{entity_type}) RETURN n LIMIT 5;"
-                    rule_based_response['example_queries'].append({
-                        "query": example_query,
-                        "description": f"Retrieve sample {entity_type} nodes"
-                    })
-                
+                    rule_based_response["example_queries"].append(
+                        {
+                            "query": example_query,
+                            "description": f"Retrieve sample {entity_type} nodes",
+                        }
+                    )
+
                 # Process relationships
                 for rel in relationships:
-                    source_entity = rel.get('source_entity')
-                    target_entity = rel.get('target_entity')
-                    relationship_type = rel.get('relationship_type')
-                    
+                    source_entity = rel.get("source_entity")
+                    target_entity = rel.get("target_entity")
+                    relationship_type = rel.get("relationship_type")
+
                     if source_entity and target_entity and relationship_type:
                         rel_query = f"MATCH (source:{source_entity}), (target:{target_entity})\nWHERE source.id = row.source_id AND target.id = row.target_id\nCREATE (source)-[:{relationship_type}]->(target);"
-                        
-                        rule_based_response['relationship_queries'].append({
-                            "query": rel_query,
-                            "description": f"Create {relationship_type} relationships between {source_entity} and {target_entity}"
-                        })
-                
+
+                        rule_based_response["relationship_queries"].append(
+                            {
+                                "query": rel_query,
+                                "description": f"Create {relationship_type} relationships between {source_entity} and {target_entity}",
+                            }
+                        )
+
                 return rule_based_response
-            
+
             # If the response is empty or invalid, fall back to rule-based generation
             if not response or not isinstance(response, dict):
-                logger.warning("LLM returned invalid response for Cypher templates, falling back to rule-based generation")
+                logger.warning(
+                    "LLM returned invalid response for Cypher templates, falling back to rule-based generation"
+                )
                 response = generate_rule_based_templates()
             else:
                 # Ensure all required keys exist in the response
-                if 'entity_creation_queries' not in response:
-                    response['entity_creation_queries'] = []
-                if 'relationship_queries' not in response:
-                    response['relationship_queries'] = []
-                if 'example_queries' not in response:
-                    response['example_queries'] = []
-                if 'constraint_queries' not in response:
-                    response['constraint_queries'] = []
-                
+                if "entity_creation_queries" not in response:
+                    response["entity_creation_queries"] = []
+                if "relationship_queries" not in response:
+                    response["relationship_queries"] = []
+                if "example_queries" not in response:
+                    response["example_queries"] = []
+                if "constraint_queries" not in response:
+                    response["constraint_queries"] = []
+
                 # If any of the query lists are empty, generate them using rule-based approach
-                if not response['entity_creation_queries'] or not response['relationship_queries']:
-                    logger.warning("LLM returned incomplete Cypher templates, filling in missing parts with rule-based generation")
+                if (
+                    not response["entity_creation_queries"]
+                    or not response["relationship_queries"]
+                ):
+                    logger.warning(
+                        "LLM returned incomplete Cypher templates, filling in missing parts with rule-based generation"
+                    )
                     rule_based = generate_rule_based_templates()
-                    
+
                     # Fill in any missing query types
-                    if not response['entity_creation_queries']:
-                        response['entity_creation_queries'] = rule_based['entity_creation_queries']
-                    if not response['relationship_queries']:
-                        response['relationship_queries'] = rule_based['relationship_queries']
-                    if not response['example_queries']:
-                        response['example_queries'] = rule_based['example_queries']
-                    if not response['constraint_queries']:
-                        response['constraint_queries'] = rule_based['constraint_queries']
-            
+                    if not response["entity_creation_queries"]:
+                        response["entity_creation_queries"] = rule_based[
+                            "entity_creation_queries"
+                        ]
+                    if not response["relationship_queries"]:
+                        response["relationship_queries"] = rule_based[
+                            "relationship_queries"
+                        ]
+                    if not response["example_queries"]:
+                        response["example_queries"] = rule_based["example_queries"]
+                    if not response["constraint_queries"]:
+                        response["constraint_queries"] = rule_based[
+                            "constraint_queries"
+                        ]
+
             # Update the state with the generated Cypher templates
-            state['cypher_query_templates'] = response
-            
+            state["cypher_query_templates"] = response
+
             # Log the number of queries generated
-            logger.info(f"Generated {len(response.get('entity_creation_queries', []))} entity creation queries, {len(response.get('relationship_queries', []))} relationship queries, and {len(response.get('example_queries', []))} example queries")
-            
+            logger.info(
+                f"Generated {len(response.get('entity_creation_queries', []))} entity creation queries, {len(response.get('relationship_queries', []))} relationship queries, and {len(response.get('example_queries', []))} example queries"
+            )
+
             return state
-            
+
         except Exception as e:
             error_msg = f"Error in Cypher template generation process: {str(e)}"
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-            
+
     except Exception as e:
         error_msg = f"Error in Cypher template generation process: {str(e)}"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state

--- a/Tabular_to_Neo4j/nodes/entity_inference/entity_classification.py
+++ b/Tabular_to_Neo4j/nodes/entity_inference/entity_classification.py
@@ -7,8 +7,12 @@ from typing import Dict, Any
 import os
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.config import UNIQUENESS_THRESHOLD
 from Tabular_to_Neo4j.nodes.entity_inference.utils import to_neo4j_property_name
 from Tabular_to_Neo4j.utils.logging_config import get_logger
@@ -16,326 +20,443 @@ from Tabular_to_Neo4j.utils.logging_config import get_logger
 # Configure logging
 logger = get_logger(__name__)
 
-def classify_entities_properties_node(state: GraphState, config: RunnableConfig) -> GraphState:
+
+def classify_entities_properties_node(
+    state: GraphState, config: RunnableConfig
+) -> GraphState:
     """First step in schema synthesis: Classify columns as entities or properties using both LLM and rule-based approaches.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with entity_property_classification and rule_based_classification
     """
     logger.info("Starting entity-property classification process")
-    
+
     # Validate required inputs
-    if state.get('column_analytics') is None or state.get('final_header') is None:
+    if state.get("column_analytics") is None or state.get("final_header") is None:
         error_msg = "Cannot classify entities/properties: missing required data"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     try:
         # Get the column analytics and header
-        analytics = state['column_analytics']
-        header = state['final_header']
-        
+        analytics = state["column_analytics"]
+        header = state["final_header"]
+
         # Get the rule-based classification from column_analytics
-        rule_based_classification = state.get('rule_based_classification', {})
-        
+        rule_based_classification = state.get("rule_based_classification", {})
+
         # Initialize LLM classification dictionary
         llm_classification = {}
-        
+
         # Process each column using both LLM and rule-based approaches
         logger.info(f"Beginning classification of {len(header)} columns")
         processed_columns = 0
         skipped_columns = 0
 
         try:
-            for column_name in state['final_header']:
+            for column_name in state["final_header"]:
                 try:
                     logger.debug(f"Processing column: '{column_name}'")
-    
+
                     # Get analytics for this column
-                    analytics = state.get('column_analytics', {}).get(column_name, {})
-    
+                    analytics = state.get("column_analytics", {}).get(column_name, {})
+
                     # Skip if we don't have analytics
                     if not analytics:
-                        logger.warning(f"Missing analytics for column '{column_name}', skipping")
+                        logger.warning(
+                            f"Missing analytics for column '{column_name}', skipping"
+                        )
                         skipped_columns += 1
                         continue
-    
+
                     # Log key analytics for debugging
-                    uniqueness = analytics.get('uniqueness', 0)
-                    null_percentage = analytics.get('null_percentage', 0)
-                    logger.debug(f"Column '{column_name}' analytics: uniqueness={uniqueness:.2f}, null_percentage={null_percentage:.2f}")
-    
+                    uniqueness = analytics.get("uniqueness", 0)
+                    null_percentage = analytics.get("null_percentage", 0)
+                    logger.debug(
+                        f"Column '{column_name}' analytics: uniqueness={uniqueness:.2f}, null_percentage={null_percentage:.2f}"
+                    )
+
                     # Get full sample rows for context and sample values for this column
                     sample_values_json = "[]"
                     full_sample_json = "[]"
-                    if state.get('processed_dataframe') is not None:
-                        df = state['processed_dataframe']
-                        
+                    if state.get("processed_dataframe") is not None:
+                        df = state["processed_dataframe"]
+
                         # Use the existing get_sample_rows and df_to_json_sample functions
-                        from Tabular_to_Neo4j.utils.csv_utils import get_sample_rows, df_to_json_sample
-                        
+                        from Tabular_to_Neo4j.utils.csv_utils import (
+                            get_sample_rows,
+                            df_to_json_sample,
+                        )
+
                         # Get sample rows (up to 5) from the entire dataframe
                         sample_count = 5
                         full_sample_df = get_sample_rows(df, sample_count)
-                        
+
                         if not full_sample_df.empty:
                             # Get the full sample data as a JSON string
                             full_sample_json = df_to_json_sample(full_sample_df)
-                            
+
                             # Extract just the values for this column as a list
                             sample_values = full_sample_df[column_name].tolist()
-                            
+
                             # Convert to JSON string
                             import json
+
                             sample_values_json = json.dumps(sample_values)
-                            logger.debug(f"Sampled {len(sample_values)} values from column '{column_name}'")
+                            logger.debug(
+                                f"Sampled {len(sample_values)} values from column '{column_name}'"
+                            )
                         else:
                             logger.warning(f"No sample data available")
                     else:
-                        logger.warning("No processed dataframe available for sampling values")
-    
+                        logger.warning(
+                            "No processed dataframe available for sampling values"
+                        )
+
                     processed_columns += 1
-    
+
                     # Get metadata for the CSV file
                     metadata = get_metadata_for_state(state)
-                    metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-    
+                    metadata_text = (
+                        format_metadata_for_prompt(metadata)
+                        if metadata
+                        else "No metadata available."
+                    )
+
                     # Check if we have a rule-based classification for this column from the state
-                    rule_based = state.get('rule_based_classification', {})
-                    rule_based_class = rule_based.get(column_name, {}).get('classification', None)
-                    
+                    rule_based = state.get("rule_based_classification", {})
+                    rule_based_class = rule_based.get(column_name, {}).get(
+                        "classification", None
+                    )
+
                     # If we have a rule-based classification with high confidence, use it directly
-                    if rule_based_class and rule_based.get(column_name, {}).get('confidence', 0) > 0.8:
-                        logger.info(f"Using rule-based classification for '{column_name}': {rule_based_class}")
+                    if (
+                        rule_based_class
+                        and rule_based.get(column_name, {}).get("confidence", 0) > 0.8
+                    ):
+                        logger.info(
+                            f"Using rule-based classification for '{column_name}': {rule_based_class}"
+                        )
                         llm_classification[column_name] = {
-                            'column_name': column_name,
-                            'classification': rule_based_class,
-                            'confidence': rule_based.get(column_name, {}).get('confidence', 0.9),
-                            'analytics': analytics,
-                            'source': 'rule_based'
+                            "column_name": column_name,
+                            "classification": rule_based_class,
+                            "confidence": rule_based.get(column_name, {}).get(
+                                "confidence", 0.9
+                            ),
+                            "analytics": analytics,
+                            "source": "rule_based",
                         }
                         continue
-    
+
                     # Format the prompt with column information and metadata
                     try:
-                        prompt = format_prompt('classify_entities_properties_v3.txt',
-                                            column_name=column_name,
-                                            full_sample_data=full_sample_json,  # Include the full sample data
-                                            uniqueness_ratio=analytics.get('uniqueness', 0),
-                                            cardinality=analytics.get('cardinality', 0),
-                                            data_type=analytics.get('data_type', 'unknown'),
-                                            missing_percentage=analytics.get('null_percentage', 0) * 100,
-                                            metadata_text=metadata_text)
+                        prompt = format_prompt(
+                            "classify_entities_properties_v3.txt",
+                            column_name=column_name,
+                            full_sample_data=full_sample_json,  # Include the full sample data
+                            uniqueness_ratio=analytics.get("uniqueness", 0),
+                            cardinality=analytics.get("cardinality", 0),
+                            data_type=analytics.get("data_type", "unknown"),
+                            missing_percentage=analytics.get("null_percentage", 0)
+                            * 100,
+                            metadata_text=metadata_text,
+                        )
                     except Exception as e:
                         error_msg = f"Error formatting prompt for column '{column_name}': {str(e)}"
                         logger.error(error_msg)
-                        state['error_messages'].append(error_msg)
-                        
+                        state["error_messages"].append(error_msg)
+
                         # Use rule-based classification if available
                         if column_name in rule_based:
                             llm_classification[column_name] = rule_based[column_name]
-                            logger.info(f"Using rule-based classification for '{column_name}' due to prompt error: {rule_based[column_name]['classification']}")
+                            logger.info(
+                                f"Using rule-based classification for '{column_name}' due to prompt error: {rule_based[column_name]['classification']}"
+                            )
                             continue
                         else:
                             # Fallback to basic heuristics
-                            fallback_classification = 'entity' if uniqueness > UNIQUENESS_THRESHOLD else 'property'
+                            fallback_classification = (
+                                "entity"
+                                if uniqueness > UNIQUENESS_THRESHOLD
+                                else "property"
+                            )
                             llm_classification[column_name] = {
-                                'column_name': column_name,
-                                'classification': fallback_classification,
-                                'confidence': 0.6,
-                                'analytics': analytics,
-                                'source': 'fallback_heuristic'
+                                "column_name": column_name,
+                                "classification": fallback_classification,
+                                "confidence": 0.6,
+                                "analytics": analytics,
+                                "source": "fallback_heuristic",
                             }
-                            logger.info(f"Using fallback classification for '{column_name}': {fallback_classification}")
+                            logger.info(
+                                f"Using fallback classification for '{column_name}': {fallback_classification}"
+                            )
                             continue
-    
+
                     # Call the LLM for entity/property classification
-                    logger.debug(f"Calling LLM for entity/property classification of column '{column_name}'")
+                    logger.debug(
+                        f"Calling LLM for entity/property classification of column '{column_name}'"
+                    )
                     try:
                         # Call the LLM for classification
-                        response = call_llm_with_json_output(prompt, state_name="classify_entities_properties")
-                        logger.debug(f"Received LLM classification response for '{column_name}': {response}")
-                        
+                        response = call_llm_with_json_output(
+                            prompt, state_name="classify_entities_properties"
+                        )
+                        logger.debug(
+                            f"Received LLM classification response for '{column_name}': {response}"
+                        )
+
                         # If response is empty or has an error, use rule-based classification
-                        if not response or 'error' in response:
-                            logger.warning(f"LLM classification failed for '{column_name}', using rule-based classification")
-                            
+                        if not response or "error" in response:
+                            logger.warning(
+                                f"LLM classification failed for '{column_name}', using rule-based classification"
+                            )
+
                             # Use rule-based classification if available
                             if column_name in rule_based:
-                                llm_classification[column_name] = rule_based[column_name]
-                                logger.info(f"Using rule-based classification for '{column_name}': {rule_based[column_name]['classification']}")
+                                llm_classification[column_name] = rule_based[
+                                    column_name
+                                ]
+                                logger.info(
+                                    f"Using rule-based classification for '{column_name}': {rule_based[column_name]['classification']}"
+                                )
                                 continue
                             else:
                                 # Fallback to basic heuristics if rule-based is not available
-                                fallback_classification = 'entity' if uniqueness > UNIQUENESS_THRESHOLD else 'property'
+                                fallback_classification = (
+                                    "entity"
+                                    if uniqueness > UNIQUENESS_THRESHOLD
+                                    else "property"
+                                )
                                 response = {
-                                    'classification': fallback_classification,
-                                    'confidence': 0.6,
-                                    'reasoning': 'Fallback classification based on uniqueness threshold.'
+                                    "classification": fallback_classification,
+                                    "confidence": 0.6,
+                                    "reasoning": "Fallback classification based on uniqueness threshold.",
                                 }
-    
+
                         # Extract the classification results
-                        classification_result = response.get('classification', '')
+                        classification_result = response.get("classification", "")
                         # Handle the case where classification_result is not a string
                         if not isinstance(classification_result, str):
-                            if isinstance(classification_result, dict) and 'type' in classification_result:
-                                classification_result = classification_result['type']
+                            if (
+                                isinstance(classification_result, dict)
+                                and "type" in classification_result
+                            ):
+                                classification_result = classification_result["type"]
                             else:
                                 # Default to using rule-based classification if available
                                 if column_name in rule_based:
-                                    classification_result = rule_based[column_name]['classification']
+                                    classification_result = rule_based[column_name][
+                                        "classification"
+                                    ]
                                 else:
                                     # Fallback based on uniqueness
-                                    classification_result = 'entity' if uniqueness > UNIQUENESS_THRESHOLD else 'property'
-                        
+                                    classification_result = (
+                                        "entity"
+                                        if uniqueness > UNIQUENESS_THRESHOLD
+                                        else "property"
+                                    )
+
                         # Normalize the classification to ensure it's either 'entity' or 'property'
                         classification_result = classification_result.lower()
-                        if 'entity' in classification_result and 'property' not in classification_result:
-                            classification_result = 'entity'
-                        elif 'property' in classification_result:
-                            classification_result = 'property'
+                        if (
+                            "entity" in classification_result
+                            and "property" not in classification_result
+                        ):
+                            classification_result = "entity"
+                        elif "property" in classification_result:
+                            classification_result = "property"
                         else:
                             # If the classification is ambiguous, use rule-based or analytics to decide
                             if column_name in rule_based:
-                                classification_result = rule_based[column_name]['classification']
-                                logger.info(f"Ambiguous LLM classification for '{column_name}', using rule-based: {classification_result}")
+                                classification_result = rule_based[column_name][
+                                    "classification"
+                                ]
+                                logger.info(
+                                    f"Ambiguous LLM classification for '{column_name}', using rule-based: {classification_result}"
+                                )
                             else:
                                 # Make a decision based on column analytics
-                                data_type = analytics.get('data_type', 'unknown')
-                                
+                                data_type = analytics.get("data_type", "unknown")
+
                                 # Numeric columns are usually properties
-                                if data_type in ['int', 'float', 'numeric']:
-                                    classification_result = 'property'
+                                if data_type in ["int", "float", "numeric"]:
+                                    classification_result = "property"
                                 # Date columns are usually properties
-                                elif data_type == 'datetime':
-                                    classification_result = 'property'
+                                elif data_type == "datetime":
+                                    classification_result = "property"
                                 # Email columns are usually properties
-                                elif 'email' in column_name.lower():
-                                    classification_result = 'property'
+                                elif "email" in column_name.lower():
+                                    classification_result = "property"
                                 # ID columns are usually properties
-                                elif 'id' in column_name.lower():
-                                    classification_result = 'property'
+                                elif "id" in column_name.lower():
+                                    classification_result = "property"
                                 # High uniqueness suggests entity
                                 elif uniqueness > UNIQUENESS_THRESHOLD:
-                                    classification_result = 'entity'
+                                    classification_result = "entity"
                                 # Default to property for safety
                                 else:
-                                    classification_result = 'property'
-                                
-                                logger.info(f"Ambiguous LLM classification for '{column_name}', using analytics-based decision: {classification_result}")
-                        
+                                    classification_result = "property"
+
+                                logger.info(
+                                    f"Ambiguous LLM classification for '{column_name}', using analytics-based decision: {classification_result}"
+                                )
+
                         # Double-check that we have a valid classification
-                        if classification_result not in ['entity', 'property']:
-                            logger.warning(f"Invalid classification '{classification_result}' for '{column_name}', defaulting to 'property'")
-                            classification_result = 'property'
-                        
+                        if classification_result not in ["entity", "property"]:
+                            logger.warning(
+                                f"Invalid classification '{classification_result}' for '{column_name}', defaulting to 'property'"
+                            )
+                            classification_result = "property"
+
                         # Handle confidence value
-                        confidence = response.get('confidence', 0.0)
+                        confidence = response.get("confidence", 0.0)
                         if not isinstance(confidence, (int, float)):
                             try:
                                 confidence = float(confidence)
                             except (ValueError, TypeError):
                                 confidence = 0.5  # Default confidence
-    
+
                         llm_classification[column_name] = {
-                            'column_name': column_name,
-                            'classification': classification_result,
-                            'confidence': confidence,
-                            'analytics': analytics,
-                            'source': 'llm'
+                            "column_name": column_name,
+                            "classification": classification_result,
+                            "confidence": confidence,
+                            "analytics": analytics,
+                            "source": "llm",
                         }
-                        
-                        logger.info(f"Classified '{column_name}' as '{classification_result}' with confidence '{confidence}' using LLM approach")
+
+                        logger.info(
+                            f"Classified '{column_name}' as '{classification_result}' with confidence '{confidence}' using LLM approach"
+                        )
                     except Exception as e:
                         # If LLM classification fails, use rule-based classification
-                        logger.warning(f"LLM classification failed for '{column_name}': {str(e)}")
-                        
+                        logger.warning(
+                            f"LLM classification failed for '{column_name}': {str(e)}"
+                        )
+
                         # Use rule-based classification if available
                         if column_name in rule_based:
                             llm_classification[column_name] = rule_based[column_name]
-                            logger.info(f"Using rule-based classification for '{column_name}': {rule_based[column_name]['classification']}")
+                            logger.info(
+                                f"Using rule-based classification for '{column_name}': {rule_based[column_name]['classification']}"
+                            )
                         else:
                             # Use a fallback classification based on column name and analytics
-                            entity_keywords = ['id', 'code', 'city', 'country', 'state', 'region', 'category']
-                            is_likely_entity = any(keyword in column_name.lower() for keyword in entity_keywords)
-                            
-                            fallback_classification = 'entity' if is_likely_entity or uniqueness > UNIQUENESS_THRESHOLD else 'property'
+                            entity_keywords = [
+                                "id",
+                                "code",
+                                "city",
+                                "country",
+                                "state",
+                                "region",
+                                "category",
+                            ]
+                            is_likely_entity = any(
+                                keyword in column_name.lower()
+                                for keyword in entity_keywords
+                            )
+
+                            fallback_classification = (
+                                "entity"
+                                if is_likely_entity or uniqueness > UNIQUENESS_THRESHOLD
+                                else "property"
+                            )
                             confidence = 0.7 if is_likely_entity else 0.6
-                            
+
                             llm_classification[column_name] = {
-                                'column_name': column_name,
-                                'classification': fallback_classification,
-                                'confidence': confidence,
-                                'analytics': analytics,
-                                'source': 'enhanced_fallback'
+                                "column_name": column_name,
+                                "classification": fallback_classification,
+                                "confidence": confidence,
+                                "analytics": analytics,
+                                "source": "enhanced_fallback",
                             }
-                            logger.info(f"Using enhanced fallback classification for '{column_name}': {fallback_classification}")
+                            logger.info(
+                                f"Using enhanced fallback classification for '{column_name}': {fallback_classification}"
+                            )
                 except Exception as column_error:
                     # If processing a specific column fails, log it and continue with the next one
-                    error_msg = f"Error processing column '{column_name}': {str(column_error)}"
+                    error_msg = (
+                        f"Error processing column '{column_name}': {str(column_error)}"
+                    )
                     logger.error(error_msg)
-                    state['error_messages'].append(error_msg)
-                    
+                    state["error_messages"].append(error_msg)
+
                     # Use rule-based classification if available
                     if column_name in rule_based:
                         llm_classification[column_name] = rule_based[column_name]
                     else:
                         # Use a default classification to ensure the pipeline continues
                         llm_classification[column_name] = {
-                            'column_name': column_name,
-                            'classification': 'error',
-                            'confidence': 0.5,
-                            'analytics': analytics if 'analytics' in locals() else {},
-                            'source': 'error_fallback'
+                            "column_name": column_name,
+                            "classification": "error",
+                            "confidence": 0.5,
+                            "analytics": analytics if "analytics" in locals() else {},
+                            "source": "error_fallback",
                         }
-            
+
             # If we processed at least one column successfully, consider it a success
             if processed_columns > 0:
-                logger.info(f"Successfully classified {processed_columns} columns, skipped {skipped_columns}")
+                logger.info(
+                    f"Successfully classified {processed_columns} columns, skipped {skipped_columns}"
+                )
             else:
                 logger.warning("No columns were successfully classified")
-                
+
         except Exception as e:
             logger.error(f"Error in classification process: {str(e)}")
             # Create a minimal classification for each column to allow the pipeline to continue
-            for column_name in state['final_header']:
+            for column_name in state["final_header"]:
                 if column_name not in llm_classification:
                     # Use rule-based classification if available, otherwise default to error
                     if column_name in rule_based_classification:
-                        llm_classification[column_name] = rule_based_classification[column_name]
+                        llm_classification[column_name] = rule_based_classification[
+                            column_name
+                        ]
                     else:
                         llm_classification[column_name] = {
-                            'column_name': column_name,
-                            'classification': 'error',
-                            'confidence': 0.5,
-                            'analytics': state.get('column_analytics', {}).get(column_name, {}),
-                            'source': 'global_error_fallback'
+                            "column_name": column_name,
+                            "classification": "error",
+                            "confidence": 0.5,
+                            "analytics": state.get("column_analytics", {}).get(
+                                column_name, {}
+                            ),
+                            "source": "global_error_fallback",
                         }
-        
+
         # Update the state with the LLM classification
-        state['entity_property_classification'] = llm_classification
-        
+        state["entity_property_classification"] = llm_classification
+
         # We don't need to generate a new rule-based classification here
         # as we're using the one from the column analytics module
-        
+
     except Exception as e:
         logger.error(f"Error classifying entities/properties: {str(e)}")
-        state['error_messages'].append(f"Error classifying entities/properties: {str(e)}")
-        
+        state["error_messages"].append(
+            f"Error classifying entities/properties: {str(e)}"
+        )
+
         # Even in case of error, try to use rule-based classification from column analytics
-        state['entity_property_classification'] = {}
-        
+        state["entity_property_classification"] = {}
+
         try:
             # Use the rule-based classification from column analytics if available
-            if 'rule_based_classification' in state and state['rule_based_classification']:
-                state['entity_property_classification'] = state['rule_based_classification']
-                logger.info("Using rule-based classification from column analytics as fallback")
+            if (
+                "rule_based_classification" in state
+                and state["rule_based_classification"]
+            ):
+                state["entity_property_classification"] = state[
+                    "rule_based_classification"
+                ]
+                logger.info(
+                    "Using rule-based classification from column analytics as fallback"
+                )
         except Exception as fallback_error:
-            logger.error(f"Error using rule-based classification as fallback: {str(fallback_error)}")
-    
+            logger.error(
+                f"Error using rule-based classification as fallback: {str(fallback_error)}"
+            )
+
     return state

--- a/Tabular_to_Neo4j/nodes/entity_inference/entity_reconciliation.py
+++ b/Tabular_to_Neo4j/nodes/entity_inference/entity_reconciliation.py
@@ -6,180 +6,256 @@ This module handles reconciling different classification approaches.
 from typing import Dict, Any
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
 from Tabular_to_Neo4j.config import UNIQUENESS_THRESHOLD
 from Tabular_to_Neo4j.nodes.entity_inference.utils import to_neo4j_property_name
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 
 # Configure logging
 logger = get_logger(__name__)
 
-def reconcile_entity_property_node(state: GraphState, config: RunnableConfig) -> GraphState:
+
+def reconcile_entity_property_node(
+    state: GraphState, config: RunnableConfig
+) -> GraphState:
     """
     Reconcile analytics-based and LLM-based classifications
     to create a consensus model of entities and properties.
     Uses LLM to reconcile different classification approaches.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with entity_property_consensus
     """
     logger.info("Starting entity-property reconciliation process")
-    
+
     # Validate required inputs
-    if state.get('entity_property_classification') is None:
+    if state.get("entity_property_classification") is None:
         error_msg = "Cannot reconcile entity/property classifications: missing entity_property_classification"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     # Debug: Log state keys to understand what's available
     logger.info(f"State keys: {list(state.keys())}")
-    
+
     # Check if rule-based classification is available from column analytics
-    has_rule_based = 'column_analytics' in state and 'rule_based_classification' in state.get('column_analytics', {})
+    has_rule_based = (
+        "column_analytics" in state
+        and "rule_based_classification" in state.get("column_analytics", {})
+    )
     if has_rule_based:
         logger.info(f"Rule-based classification exists in column analytics")
     else:
-        logger.info("Rule-based classification is missing in column analytics - will use only LLM classification")
-    
+        logger.info(
+            "Rule-based classification is missing in column analytics - will use only LLM classification"
+        )
+
     try:
         # Get the LLM classification
-        llm_classification = state['entity_property_classification']
-        
+        llm_classification = state["entity_property_classification"]
+
         # Get rule-based classification from column analytics if available
         if has_rule_based:
-            rule_based_classification = state['column_analytics']['rule_based_classification']
-            logger.info(f"Using rule-based classification from column analytics with {len(rule_based_classification)} entries")
+            rule_based_classification = state["column_analytics"][
+                "rule_based_classification"
+            ]
+            logger.info(
+                f"Using rule-based classification from column analytics with {len(rule_based_classification)} entries"
+            )
         # Create rule-based classification directly from analytics if not in column analytics
         else:
             logger.info("Creating rule-based classification from analytics")
             rule_based_classification = {}
-            
-            for column_name, analytics_data in state.get('column_analytics', {}).items():
-                if isinstance(analytics_data, dict) and 'column_name' in analytics_data:
-                    uniqueness = analytics_data.get('uniqueness', 0)
-                    cardinality = analytics_data.get('cardinality', 0)
-                    data_type = analytics_data.get('data_type', '')
-                    patterns = analytics_data.get('patterns', {})
-                    
+
+            for column_name, analytics_data in state.get(
+                "column_analytics", {}
+            ).items():
+                if isinstance(analytics_data, dict) and "column_name" in analytics_data:
+                    uniqueness = analytics_data.get("uniqueness", 0)
+                    cardinality = analytics_data.get("cardinality", 0)
+                    data_type = analytics_data.get("data_type", "")
+                    patterns = analytics_data.get("patterns", {})
+
                     # Force classification as property for specific data types
-                    if data_type in ['date', 'datetime', 'float', 'integer']:
+                    if data_type in ["date", "datetime", "float", "integer"]:
                         classification = "property"
                         confidence = 1.0
                     # Check for email pattern
-                    elif 'email' in patterns and patterns['email'] > 0.5:
+                    elif "email" in patterns and patterns["email"] > 0.5:
                         classification = "property"
                         confidence = 1.0
                     # Check for numeric patterns
-                    elif any(p in patterns for p in ['phone', 'credit_card', 'numeric_id']) and patterns.get(next((p for p in patterns if p in ['phone', 'credit_card', 'numeric_id']), None), 0) > 0.5:
+                    elif (
+                        any(
+                            p in patterns
+                            for p in ["phone", "credit_card", "numeric_id"]
+                        )
+                        and patterns.get(
+                            next(
+                                (
+                                    p
+                                    for p in patterns
+                                    if p in ["phone", "credit_card", "numeric_id"]
+                                ),
+                                None,
+                            ),
+                            0,
+                        )
+                        > 0.5
+                    ):
                         classification = "property"
                         confidence = 1.0
                     # Apply standard rules
                     elif uniqueness > UNIQUENESS_THRESHOLD:
                         classification = "entity"
                         confidence = 0.8
-                    elif cardinality < len(state.get('processed_dataframe', [])) * 0.1 and cardinality > 1:
+                    elif (
+                        cardinality < len(state.get("processed_dataframe", [])) * 0.1
+                        and cardinality > 1
+                    ):
                         classification = "entity"
                         confidence = 0.7
                     else:
                         classification = "property"
                         confidence = 0.6
-                        
+
                     rule_based_classification[column_name] = {
-                        'column_name': column_name,
-                        'classification': classification,
-                        'confidence': confidence,
-                        'analytics': analytics_data,
-                        'source': 'rule_based'
+                        "column_name": column_name,
+                        "classification": classification,
+                        "confidence": confidence,
+                        "analytics": analytics_data,
+                        "source": "rule_based",
                     }
-            
-            logger.info(f"Created rule-based classification for {len(rule_based_classification)} columns")
-        
+
+            logger.info(
+                f"Created rule-based classification for {len(rule_based_classification)} columns"
+            )
+
         # Initialize consensus dictionary
         consensus = {}
-        
+
         # Process each column to determine if reconciliation is needed
-        for column_name in state.get('final_header', []):
+        for column_name in state.get("final_header", []):
             # Get both classifications for this column
             llm_info = llm_classification.get(column_name, {})
             rule_info = rule_based_classification.get(column_name, {})
-            
+
             # Skip if we don't have both classifications
             if not llm_info and not rule_info:
-                logger.warning(f"Missing classification for column '{column_name}', using fallback classification")
-                
+                logger.warning(
+                    f"Missing classification for column '{column_name}', using fallback classification"
+                )
+
                 # Use a fallback classification based on column name patterns
-                fallback_classification = 'entity' if 'id' in column_name.lower() or 'name' in column_name.lower() else 'property'
-                consensus[column_name] = {'column_name': column_name, 'classification': fallback_classification, 'confidence': 0.5}
+                fallback_classification = (
+                    "entity"
+                    if "id" in column_name.lower() or "name" in column_name.lower()
+                    else "property"
+                )
+                consensus[column_name] = {
+                    "column_name": column_name,
+                    "classification": fallback_classification,
+                    "confidence": 0.5,
+                }
                 continue
             elif not llm_info:
-                logger.warning(f"Missing LLM classification for column '{column_name}', using rule-based classification")
+                logger.warning(
+                    f"Missing LLM classification for column '{column_name}', using rule-based classification"
+                )
                 consensus[column_name] = rule_info
                 continue
             elif not rule_info:
-                logger.warning(f"Missing rule-based classification for column '{column_name}', using LLM classification")
+                logger.warning(
+                    f"Missing rule-based classification for column '{column_name}', using LLM classification"
+                )
                 consensus[column_name] = llm_info
                 continue
-            
+
             # Check if there's a discrepancy between the classifications
-            llm_classification_result = llm_info.get('classification', '')
-            rule_classification_result = rule_info.get('classification', '')
-            
+            llm_classification_result = llm_info.get("classification", "")
+            rule_classification_result = rule_info.get("classification", "")
+
             # If classifications match, no need for reconciliation
             if llm_classification_result == rule_classification_result:
-                logger.info(f"Classifications match for column '{column_name}': {llm_classification_result}")
-                
+                logger.info(
+                    f"Classifications match for column '{column_name}': {llm_classification_result}"
+                )
+
                 # Use the LLM classification as it typically has more detailed reasoning
                 consensus[column_name] = llm_info
                 continue
-            
+
             # If there's a discrepancy, perform reconciliation
-            logger.info(f"Classification discrepancy for '{column_name}': LLM={llm_classification_result}, Rule={rule_classification_result}")
-            
+            logger.info(
+                f"Classification discrepancy for '{column_name}': LLM={llm_classification_result}, Rule={rule_classification_result}"
+            )
+
             # Get confidence scores for both classifications
-            llm_confidence = llm_info.get('confidence', 0.5)
-            rule_confidence = rule_info.get('confidence', 0.5)
-            
+            llm_confidence = llm_info.get("confidence", 0.5)
+            rule_confidence = rule_info.get("confidence", 0.5)
+
             # Special case: If rule-based classification has maximum confidence (1.0), it means
             # we have a forced property classification based on data type or pattern detection
             # (e.g., emails, dates, numeric values) - always use this classification
-            if rule_confidence == 1.0 and rule_classification_result == 'property':
-                logger.info(f"Using rule-based classification for '{column_name}' due to forced property classification")
+            if rule_confidence == 1.0 and rule_classification_result == "property":
+                logger.info(
+                    f"Using rule-based classification for '{column_name}' due to forced property classification"
+                )
                 consensus[column_name] = rule_info
                 continue
-            
-            # Reconciliation strategy: 
+
+            # Reconciliation strategy:
             # 1. Compare confidence scores
             # 2. If one is significantly higher, use that classification
             # 3. Otherwise, prefer LLM classification as it's more contextual
-            
-            if llm_confidence >= rule_confidence + 0.2:  # LLM is significantly more confident
-                logger.info(f"Using LLM classification for '{column_name}' due to higher confidence: {llm_confidence} vs {rule_confidence}")
+
+            if (
+                llm_confidence >= rule_confidence + 0.2
+            ):  # LLM is significantly more confident
+                logger.info(
+                    f"Using LLM classification for '{column_name}' due to higher confidence: {llm_confidence} vs {rule_confidence}"
+                )
                 consensus[column_name] = llm_info
-            elif rule_confidence >= llm_confidence + 0.2:  # Rule-based is significantly more confident
-                logger.info(f"Using rule-based classification for '{column_name}' due to higher confidence: {rule_confidence} vs {llm_confidence}")
+            elif (
+                rule_confidence >= llm_confidence + 0.2
+            ):  # Rule-based is significantly more confident
+                logger.info(
+                    f"Using rule-based classification for '{column_name}' due to higher confidence: {rule_confidence} vs {llm_confidence}"
+                )
                 consensus[column_name] = rule_info
             else:  # Similar confidence levels, prefer LLM
-                logger.info(f"Using LLM classification for '{column_name}' as default reconciliation strategy")
+                logger.info(
+                    f"Using LLM classification for '{column_name}' as default reconciliation strategy"
+                )
                 consensus[column_name] = llm_info
-        
+
         # Add uniqueness information for entities to help with later processing
         for column_name, info in consensus.items():
-            if info['classification'] == 'entity':
-                analytics = state.get('column_analytics', {}).get(column_name, {})
-                info['uniqueness_ratio'] = analytics.get('uniqueness', 0)  # Updated field name
-        
+            if info["classification"] == "entity":
+                analytics = state.get("column_analytics", {}).get(column_name, {})
+                info["uniqueness_ratio"] = analytics.get(
+                    "uniqueness", 0
+                )  # Updated field name
+
         # Update the state
-        state['entity_property_consensus'] = consensus
-        
+        state["entity_property_consensus"] = consensus
+
     except Exception as e:
         logger.error(f"Error reconciling entity/property classifications: {str(e)}")
-        state['error_messages'].append(f"Error reconciling entity/property classifications: {str(e)}")
-        state['entity_property_consensus'] = state.get('entity_property_classification', {})
-    
+        state["error_messages"].append(
+            f"Error reconciling entity/property classifications: {str(e)}"
+        )
+        state["entity_property_consensus"] = state.get(
+            "entity_property_classification", {}
+        )
+
     return state

--- a/Tabular_to_Neo4j/nodes/entity_inference/relationship_inference.py
+++ b/Tabular_to_Neo4j/nodes/entity_inference/relationship_inference.py
@@ -6,215 +6,281 @@ This module handles inferring relationships between entity types.
 from typing import Dict, Any, List
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 from Tabular_to_Neo4j.config import MAX_SAMPLE_ROWS
+
 # Configure logging
 logger = get_logger(__name__)
 
-def infer_entity_relationships_node(state: GraphState, config: RunnableConfig) -> GraphState:
+
+def infer_entity_relationships_node(
+    state: GraphState, config: RunnableConfig
+) -> GraphState:
     """
     Infer relationships between entities based on property mapping and entity types.
     Uses LLM to determine the most likely relationships between entities.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with entity_relationships
     """
     logger.info("Starting entity relationship inference process")
-    
+
     # Validate required inputs
-    if state.get('property_entity_mapping') is None:
+    if state.get("property_entity_mapping") is None:
         error_msg = "Cannot infer entity relationships: missing property-entity mapping"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     try:
         # Get the property-entity mapping
-        mapping = state['property_entity_mapping']
-        
+        mapping = state["property_entity_mapping"]
+
         # Get column analytics if available
-        column_analytics = state.get('column_analytics', {})
-        
+        column_analytics = state.get("column_analytics", {})
+
         # Extract entity types with their properties and analytics
         entities_with_properties = []
         for entity_type, entity_data in mapping.items():
-            if entity_data.get('type') == 'entity':
-                properties = entity_data.get('properties', [])
-                
+            if entity_data.get("type") == "entity":
+                properties = entity_data.get("properties", [])
+
                 # Enhance properties with analytics data if available
                 enhanced_properties = []
                 for prop in properties:
-                    column_name = prop.get('column_name', '')
+                    column_name = prop.get("column_name", "")
                     enhanced_prop = prop.copy()
-                    
+
                     # Add analytics data if available
                     if column_name in column_analytics:
                         analytics = column_analytics[column_name]
-                        enhanced_prop['analytics'] = {
-                            'data_type': analytics.get('data_type', 'unknown'),
-                            'uniqueness_ratio': analytics.get('uniqueness_ratio', 0),
-                            'cardinality': analytics.get('cardinality', 0),
-                            'missing_percentage': analytics.get('missing_percentage', 0),
-                            'sample_values': analytics.get('sample_values', [])
+                        enhanced_prop["analytics"] = {
+                            "data_type": analytics.get("data_type", "unknown"),
+                            "uniqueness_ratio": analytics.get("uniqueness_ratio", 0),
+                            "cardinality": analytics.get("cardinality", 0),
+                            "missing_percentage": analytics.get(
+                                "missing_percentage", 0
+                            ),
+                            "sample_values": analytics.get("sample_values", []),
                         }
-                    
+
                     enhanced_properties.append(enhanced_prop)
-                
-                entities_with_properties.append({
-                    'entity_type': entity_type,
-                    'properties': enhanced_properties
-                })
-        
-        entity_types = [entity['entity_type'] for entity in entities_with_properties]
-        logger.info(f"Found {len(entity_types)} entity types for relationship inference: {', '.join(entity_types)}")
-        
+
+                entities_with_properties.append(
+                    {"entity_type": entity_type, "properties": enhanced_properties}
+                )
+
+        entity_types = [entity["entity_type"] for entity in entities_with_properties]
+        logger.info(
+            f"Found {len(entity_types)} entity types for relationship inference: {', '.join(entity_types)}"
+        )
+
         # If we have 0 or 1 entity types, there are no relationships to infer
         if len(entity_types) <= 1:
-            logger.info(f"Found {len(entity_types)} entity types, no relationships to infer")
-            
+            logger.info(
+                f"Found {len(entity_types)} entity types, no relationships to infer"
+            )
+
             # Still format the prompt and save it as a sample, even though we won't call the LLM
             # This ensures we have complete prompt samples for all steps
             metadata = get_metadata_for_state(state)
-            metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-            
+            metadata_text = (
+                format_metadata_for_prompt(metadata)
+                if metadata
+                else "No metadata available."
+            )
+
             # Format the prompt with entity information and metadata
-            prompt = format_prompt('infer_entity_relationships.txt',
-                                  entity_property_consensus=str(state.get('entity_property_consensus', {})),
-                                  property_entity_mapping=str(mapping),
-                                  metadata_text=metadata_text,
-                                  sample_data=str(state.get('processed_dataframe', {}).head(5).to_dict(orient='records') if state.get('processed_dataframe') is not None else {}))
-            
+            prompt = format_prompt(
+                "infer_entity_relationships.txt",
+                entity_property_consensus=str(
+                    state.get("entity_property_consensus", {})
+                ),
+                property_entity_mapping=str(mapping),
+                metadata_text=metadata_text,
+                sample_data=str(
+                    state.get("processed_dataframe", {})
+                    .head(5)
+                    .to_dict(orient="records")
+                    if state.get("processed_dataframe") is not None
+                    else {}
+                ),
+            )
+
             # Save the prompt sample without actually calling the LLM
-            from Tabular_to_Neo4j.utils.llm_manager import save_prompt_sample
-            save_prompt_sample('infer_entity_relationships.txt', prompt, {"state_name": "infer_entity_relationships"})
-            
+            from Tabular_to_Neo4j.utils.prompt_utils import save_prompt_sample
+
+            save_prompt_sample(
+                "infer_entity_relationships.txt",
+                prompt,
+                {"state_name": "infer_entity_relationships"},
+            )
+
             # Add a note in the prompt sample that this was skipped due to insufficient entity types
             skipped_note = "\n\nNOTE: LLM call was skipped because there were insufficient entity types to infer relationships."
-            save_prompt_sample('infer_entity_relationships_skipped.txt', skipped_note, {"state_name": "infer_entity_relationships"})
-            
-            state['entity_relationships'] = []
+            save_prompt_sample(
+                "infer_entity_relationships_skipped.txt",
+                skipped_note,
+                {"state_name": "infer_entity_relationships"},
+            )
+
+            state["entity_relationships"] = []
             return state
-        
+
         # Get metadata for the CSV file
         metadata = get_metadata_for_state(state)
-        metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-        
+        metadata_text = (
+            format_metadata_for_prompt(metadata)
+            if metadata
+            else "No metadata available."
+        )
+
         # Get the processed dataframe for sample data if available
         sample_data = ""
-        if state.get('processed_dataframe') is not None:
-            df = state['processed_dataframe']
+        if state.get("processed_dataframe") is not None:
+            df = state["processed_dataframe"]
             if not df.empty:
                 # Get a small sample of the data (first MAX_SAMPLE_ROWS rows)
                 try:
-                    sample_data = df.head(MAX_SAMPLE_ROWS).to_dict(orient='records')
+                    sample_data = df.head(MAX_SAMPLE_ROWS).to_dict(orient="records")
                     sample_data = str(sample_data)  # Convert to string for the prompt
                 except Exception as e:
                     logger.warning(f"Error converting dataframe to dict: {str(e)}")
                     # Fallback to string representation
                     sample_data = df.head(MAX_SAMPLE_ROWS).to_string(index=False)
-        
+
         # Format the prompt with entity information and metadata
-        prompt = format_prompt('infer_entity_relationships.txt',
-                              entity_property_consensus=str(state.get('entity_property_consensus', {})),
-                              property_entity_mapping=str(mapping),
-                              metadata_text=metadata_text,
-                              sample_data=sample_data)
-        
+        prompt = format_prompt(
+            "infer_entity_relationships.txt",
+            entity_property_consensus=str(state.get("entity_property_consensus", {})),
+            property_entity_mapping=str(mapping),
+            metadata_text=metadata_text,
+            sample_data=sample_data,
+        )
+
         # Call the LLM for relationship inference
         logger.info("Calling LLM to infer relationships between entities")
-        response = call_llm_with_json_output(prompt, state_name="infer_entity_relationships")
-        
+        response = call_llm_with_json_output(
+            prompt, state_name="infer_entity_relationships"
+        )
+
         # Extract the inferred relationships
-        inferred_relationships = response.get('entity_relationships', [])
-        
+        inferred_relationships = response.get("entity_relationships", [])
+
         # Get the list of entity types from the mapping
-        entity_types = [entity_type for entity_type, data in mapping.items() if data.get('type') == 'entity']
+        entity_types = [
+            entity_type
+            for entity_type, data in mapping.items()
+            if data.get("type") == "entity"
+        ]
         logger.info(f"Identified entity types: {entity_types}")
-        
+
         # Use a pairwise approach to infer relationships between each pair of entities
         all_relationships = []
         processed_pairs = set()  # Track which pairs we've already processed
-        
+
         # For each pair of entities, infer the relationship between them
         for i, entity1 in enumerate(entity_types):
             for j, entity2 in enumerate(entity_types):
                 # Skip self-relationships
                 if i == j:
                     continue
-                
+
                 # Create a pair identifier (sorted to ensure we don't process the same pair twice)
                 pair = tuple(sorted([entity1, entity2]))
-                
+
                 # Skip if we've already processed this pair
                 if pair in processed_pairs:
                     continue
-                
+
                 processed_pairs.add(pair)
-                logger.info(f"Inferring relationship between entities: {pair[0]} and {pair[1]}")
-                
+                logger.info(
+                    f"Inferring relationship between entities: {pair[0]} and {pair[1]}"
+                )
+
                 # Format a focused prompt specifically for this entity pair
-                focused_prompt = format_prompt('infer_entity_relationship_pair.txt',
-                                              source_entity=pair[0],
-                                              target_entity=pair[1],
-                                              entity_property_consensus=str(state.get('entity_property_consensus', {})),
-                                              property_entity_mapping=str(mapping),
-                                              metadata_text=metadata_text,
-                                              sample_data=sample_data)
-                
+                focused_prompt = format_prompt(
+                    "infer_entity_relationship_pair.txt",
+                    source_entity=pair[0],
+                    target_entity=pair[1],
+                    entity_property_consensus=str(
+                        state.get("entity_property_consensus", {})
+                    ),
+                    property_entity_mapping=str(mapping),
+                    metadata_text=metadata_text,
+                    sample_data=sample_data,
+                )
+
                 # Call the LLM for this specific entity pair
-                pair_response = call_llm_with_json_output(focused_prompt, state_name=f"infer_relationship_{pair[0]}_{pair[1]}")
-                
+                pair_response = call_llm_with_json_output(
+                    focused_prompt, state_name=f"infer_relationship_{pair[0]}_{pair[1]}"
+                )
+
                 # Extract the inferred relationship
-                pair_relationships = pair_response.get('entity_relationships', [])
-                
+                pair_relationships = pair_response.get("entity_relationships", [])
+
                 # Add valid relationships to the overall list
                 for rel in pair_relationships:
-                    source = rel.get('source_entity', '')
-                    target = rel.get('target_entity', '')
-                    rel_type = rel.get('relationship_type', '')
-                    confidence = rel.get('confidence', 0.0)
-                    bidirectional = rel.get('bidirectional', False)
-                    reasoning = rel.get('reasoning', '')
-                    
+                    source = rel.get("source_entity", "")
+                    target = rel.get("target_entity", "")
+                    rel_type = rel.get("relationship_type", "")
+                    confidence = rel.get("confidence", 0.0)
+                    bidirectional = rel.get("bidirectional", False)
+                    reasoning = rel.get("reasoning", "")
+
                     # Validate the relationship has required fields and sufficient confidence
                     if source and target and rel_type and confidence > 0.5:
                         # Add the primary relationship
                         all_relationships.append(rel)
-                        logger.info(f"Valid relationship: ({source})-[{rel_type}]->({target}) with confidence {confidence}")
+                        logger.info(
+                            f"Valid relationship: ({source})-[{rel_type}]->({target}) with confidence {confidence}"
+                        )
                         if reasoning:
                             logger.info(f"Reasoning: {reasoning}")
-                        
+
                         # If bidirectional, add the reverse relationship too
                         if bidirectional:
                             # Create a reverse relationship with the same type
                             reverse_rel = {
-                                'source_entity': target,
-                                'target_entity': source,
-                                'relationship_type': rel_type,
-                                'confidence': confidence,
-                                'bidirectional': True,
-                                'reasoning': f"Reverse of bidirectional relationship: {reasoning}"
+                                "source_entity": target,
+                                "target_entity": source,
+                                "relationship_type": rel_type,
+                                "confidence": confidence,
+                                "bidirectional": True,
+                                "reasoning": f"Reverse of bidirectional relationship: {reasoning}",
                             }
                             all_relationships.append(reverse_rel)
-                            logger.info(f"Added reverse relationship: ({target})-[{rel_type}]->({source}) (bidirectional)")
+                            logger.info(
+                                f"Added reverse relationship: ({target})-[{rel_type}]->({source}) (bidirectional)"
+                            )
                     else:
-                        logger.warning(f"Filtered out invalid relationship: {rel} - missing required fields or low confidence")
-        
+                        logger.warning(
+                            f"Filtered out invalid relationship: {rel} - missing required fields or low confidence"
+                        )
+
         # Log the final relationships
-        logger.info(f"Inferred {len(all_relationships)} valid relationships between entities")
-        
+        logger.info(
+            f"Inferred {len(all_relationships)} valid relationships between entities"
+        )
+
         # Update the state with all valid relationships
-        state['entity_relationships'] = all_relationships
-        
+        state["entity_relationships"] = all_relationships
+
     except Exception as e:
         logger.error(f"Error inferring entity relationships: {str(e)}")
-        state['error_messages'].append(f"Error inferring entity relationships: {str(e)}")
-        state['entity_relationships'] = []
-    
+        state["error_messages"].append(
+            f"Error inferring entity relationships: {str(e)}"
+        )
+        state["entity_relationships"] = []
+
     return state

--- a/Tabular_to_Neo4j/nodes/header_processing/header_inference.py
+++ b/Tabular_to_Neo4j/nodes/header_processing/header_inference.py
@@ -8,82 +8,93 @@ import pandas as pd
 import os
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
 from Tabular_to_Neo4j.utils.csv_utils import df_to_json_sample
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.config import MAX_SAMPLE_ROWS
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 
 # Configure logging
 logger = get_logger(__name__)
 
+
 def infer_header_llm_node(state: GraphState, config: RunnableConfig) -> GraphState:
     """
     Use LLM to infer appropriate headers when no header is detected.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with inferred_header and final_header
     """
-    if state.get('raw_dataframe') is None:
+    if state.get("raw_dataframe") is None:
         error_msg = "Cannot infer header: no raw dataframe available"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     logger.info("Using LLM to infer headers for the CSV file")
-    
+
     try:
-        df = state['raw_dataframe']
-        
+        df = state["raw_dataframe"]
+
         # Get a sample of the data for the LLM
         sample_rows = min(MAX_SAMPLE_ROWS, len(df))
         data_sample = df_to_json_sample(df, sample_rows)
-        
+
         # Get file name for the prompt
-        file_name = os.path.basename(state.get('csv_file_path', 'unknown.csv'))
-        
+        file_name = os.path.basename(state.get("csv_file_path", "unknown.csv"))
+
         # Get metadata for the CSV file
         metadata = get_metadata_for_state(state)
-        metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-        
+        metadata_text = (
+            format_metadata_for_prompt(metadata)
+            if metadata
+            else "No metadata available."
+        )
+
         # Format the prompt with the data sample and metadata
-        prompt = format_prompt('infer_header.txt',
-                              metadata_text=metadata_text,
-                              num_columns=len(df.columns),
-                              data_sample=data_sample)
-        
+        prompt = format_prompt(
+            "infer_header.txt",
+            metadata_text=metadata_text,
+            num_columns=len(df.columns),
+            data_sample=data_sample,
+        )
+
         # Call the LLM to infer headers
         logger.debug("Calling LLM for header inference")
         response = call_llm_with_json_output(prompt, state_name="infer_header")
-        
+
         # Extract the inferred headers
         inferred_header = response
-        
+
         # Validate the response
         if not isinstance(inferred_header, list):
             error_msg = f"LLM did not return a list of headers: {inferred_header}"
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-        
+
         if len(inferred_header) != len(df.columns):
             error_msg = f"LLM returned {len(inferred_header)} headers, but CSV has {len(df.columns)} columns"
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-        
+
         # Update the state with the inferred headers
         logger.info(f"Successfully inferred headers: {inferred_header}")
-        state['inferred_header'] = inferred_header
-        state['final_header'] = inferred_header
-        
+        state["inferred_header"] = inferred_header
+        state["final_header"] = inferred_header
+
     except Exception as e:
         error_msg = f"Error inferring headers: {str(e)}"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
-    
+        state["error_messages"].append(error_msg)
+
     return state

--- a/Tabular_to_Neo4j/nodes/header_processing/header_translation.py
+++ b/Tabular_to_Neo4j/nodes/header_processing/header_translation.py
@@ -8,86 +8,103 @@ import pandas as pd
 import os
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 
 # Configure logging
 logger = get_logger(__name__)
 
+
 def translate_header_llm_node(state: GraphState, config: RunnableConfig) -> GraphState:
     """
     Use LLM to translate headers to match the metadata language.
     This node is only called if the detect_header_language_node determined translation is needed.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with translated_header and potentially updated final_header
     """
-    if state.get('final_header') is None:
+    if state.get("final_header") is None:
         error_msg = "Cannot translate header: no header available"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     # Get the header language and metadata language
-    header_language = state.get('header_language', 'Unknown')
-    metadata_language = state.get('metadata_language', 'English')
-    
-    logger.info(f"Using LLM to translate headers from {header_language} to {metadata_language}")
-    
+    header_language = state.get("header_language", "Unknown")
+    metadata_language = state.get("metadata_language", "English")
+
+    logger.info(
+        f"Using LLM to translate headers from {header_language} to {metadata_language}"
+    )
+
     try:
-        header = state['final_header']
-        
+        header = state["final_header"]
+
         # Get file name for the prompt
-        file_name = os.path.basename(state.get('csv_file_path', 'unknown.csv'))
-        
+        file_name = os.path.basename(state.get("csv_file_path", "unknown.csv"))
+
         # Get metadata for the CSV file
         metadata = get_metadata_for_state(state)
-        metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-        
+        metadata_text = (
+            format_metadata_for_prompt(metadata)
+            if metadata
+            else "No metadata available."
+        )
+
         # Format the prompt with the header, language information, and metadata
-        prompt = format_prompt('translate_header.txt',
-                              file_name=file_name,
-                              header=header,
-                              source_language=header_language,
-                              target_language=metadata_language,
-                              metadata_text=metadata_text)
-        
+        prompt = format_prompt(
+            "translate_header.txt",
+            file_name=file_name,
+            header=header,
+            source_language=header_language,
+            target_language=metadata_language,
+            metadata_text=metadata_text,
+        )
+
         # Call the LLM to translate headers
         logger.debug("Calling LLM for header translation")
         response = call_llm_with_json_output(prompt, state_name="translate_header")
-        
+
         # Extract the translated headers
         translated_header = response
-        
+
         # Validate the response
         if not isinstance(translated_header, list):
-            error_msg = f"LLM did not return a list of translated headers: {translated_header}"
+            error_msg = (
+                f"LLM did not return a list of translated headers: {translated_header}"
+            )
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-        
+
         if len(translated_header) != len(header):
             error_msg = f"LLM returned {len(translated_header)} headers, but original has {len(header)} columns"
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-        
+
         # Update the state with the translated headers
-        logger.info(f"Successfully translated headers from {source_language} to {TARGET_HEADER_LANGUAGE}")
+        logger.info(
+            f"Successfully translated headers from {source_language} to {TARGET_HEADER_LANGUAGE}"
+        )
         logger.debug(f"Original headers: {header}")
         logger.debug(f"Translated headers: {translated_header}")
-        
-        state['translated_header'] = translated_header
-        state['final_header'] = translated_header
-        
+
+        state["translated_header"] = translated_header
+        state["final_header"] = translated_header
+
     except Exception as e:
         error_msg = f"Error translating headers: {str(e)}"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
-    
+        state["error_messages"].append(error_msg)
+
     return state

--- a/Tabular_to_Neo4j/nodes/header_processing/header_validation.py
+++ b/Tabular_to_Neo4j/nodes/header_processing/header_validation.py
@@ -8,125 +8,147 @@ import pandas as pd
 import os
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
-from Tabular_to_Neo4j.utils.llm_manager import format_prompt, call_llm_with_json_output
+from Tabular_to_Neo4j.utils.prompt_utils import format_prompt
+from Tabular_to_Neo4j.utils.llm_manager import call_llm_with_json_output
 from Tabular_to_Neo4j.utils.csv_utils import df_to_json_sample
-from Tabular_to_Neo4j.utils.metadata_utils import get_metadata_for_state, format_metadata_for_prompt
+from Tabular_to_Neo4j.utils.metadata_utils import (
+    get_metadata_for_state,
+    format_metadata_for_prompt,
+)
 from Tabular_to_Neo4j.config import MAX_SAMPLE_ROWS
 from Tabular_to_Neo4j.utils.logging_config import get_logger
 
 # Configure logging
 logger = get_logger(__name__)
 
+
 def validate_header_llm_node(state: GraphState, config: RunnableConfig) -> GraphState:
     """
     Use LLM to validate and potentially improve headers.
-    
+
     Args:
         state: The current graph state
         config: LangGraph runnable configuration
-        
+
     Returns:
         Updated graph state with validated_header and potentially updated final_header
     """
-    if state.get('raw_dataframe') is None or state.get('final_header') is None:
+    if state.get("raw_dataframe") is None or state.get("final_header") is None:
         error_msg = "Cannot validate header: missing raw dataframe or header"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
+        state["error_messages"].append(error_msg)
         return state
-    
+
     logger.info("Using LLM to validate and improve headers")
-    
+
     try:
-        df = state['raw_dataframe']
-        current_header = state['final_header']
-        
+        df = state["raw_dataframe"]
+        current_header = state["final_header"]
+
         # Get a sample of the data for the LLM
         sample_rows = min(MAX_SAMPLE_ROWS, len(df))
         data_sample = df_to_json_sample(df, sample_rows)
-        
+
         # File name is no longer needed for the prompt as per requirements
         # We'll keep the csv_file_path in the state for other nodes that might need it
-        
+
         # Get metadata for the CSV file
         metadata = get_metadata_for_state(state)
-        metadata_text = format_metadata_for_prompt(metadata) if metadata else "No metadata available."
-        
+        metadata_text = (
+            format_metadata_for_prompt(metadata)
+            if metadata
+            else "No metadata available."
+        )
+
         # Log the header and metadata for debugging
         logger.debug(f"Current header: {current_header}")
         logger.debug(f"Metadata: {metadata}")
-        
+
         # Set default values if validation fails
-        state['validated_header'] = current_header.copy() if isinstance(current_header, list) else current_header
-        
+        state["validated_header"] = (
+            current_header.copy()
+            if isinstance(current_header, list)
+            else current_header
+        )
+
         # Extract language from metadata if available
-        metadata_language = metadata.get('language', 'english') if metadata else 'english'
+        metadata_language = (
+            metadata.get("language", "english") if metadata else "english"
+        )
         logger.info(f"Metadata language: {metadata_language}")
-        
+
         # Store metadata language in state for language detection node
-        if 'metadata_language' not in state:
-            state['metadata_language'] = metadata_language
-            state['metadata_language_confidence'] = 1.0  # High confidence since it's from metadata
-        
+        if "metadata_language" not in state:
+            state["metadata_language"] = metadata_language
+            state["metadata_language_confidence"] = (
+                1.0  # High confidence since it's from metadata
+            )
+
         # Convert current_header to JSON string for consistent formatting
         import json
+
         headers_json = json.dumps(current_header)
-        
-        prompt = format_prompt('validate_header.txt',
-                               data_sample=data_sample,
-                               headers=headers_json,  # Pass headers instead of current_header
-                               column_count=len(df.columns),
-                               row_count=len(df),
-                               metadata_text=metadata_text)
-        
+
+        prompt = format_prompt(
+            "validate_header.txt",
+            data_sample=data_sample,
+            headers=headers_json,  # Pass headers instead of current_header
+            column_count=len(df.columns),
+            row_count=len(df),
+            metadata_text=metadata_text,
+        )
+
         # Call the LLM to validate headers
         logger.debug("Calling LLM for header validation")
         response = call_llm_with_json_output(prompt, state_name="validate_header")
-        
+
         # Extract the validation results (no is_correct field as per requirements)
-        validated_header = response.get('validated_header', current_header)
-        suggestions = response.get('suggestions', '')
-        
+        validated_header = response.get("validated_header", current_header)
+        suggestions = response.get("suggestions", "")
+
         # Validate the response
         if not isinstance(validated_header, list):
             # Try to handle the case where the response is a string
             if isinstance(validated_header, str):
                 # Try to parse it as a comma-separated list
                 try:
-                    validated_header = [h.strip() for h in validated_header.split(',')]
+                    validated_header = [h.strip() for h in validated_header.split(",")]
                 except Exception:
                     # If that fails, just use the current header
-                    logger.warning(f"Could not parse validated_header as list: {validated_header}")
+                    logger.warning(
+                        f"Could not parse validated_header as list: {validated_header}"
+                    )
                     validated_header = current_header
             else:
                 # If it's not a string or a list, use the current header
                 error_msg = f"LLM did not return a list of headers: {validated_header}"
                 logger.error(error_msg)
-                state['error_messages'].append(error_msg)
+                state["error_messages"].append(error_msg)
                 validated_header = current_header
-        
+
         if len(validated_header) != len(df.columns):
             error_msg = f"LLM returned {len(validated_header)} headers, but CSV has {len(df.columns)} columns"
             logger.error(error_msg)
-            state['error_messages'].append(error_msg)
+            state["error_messages"].append(error_msg)
             return state
-        
+
         # Update the state with the validated headers
-        state['validated_header'] = validated_header
-        
+        state["validated_header"] = validated_header
+
         # Check if the validated header is different from the current header
         headers_changed = validated_header != current_header
-        
+
         # If the headers changed or there are suggestions, update the final header
         if headers_changed:
             logger.info(f"LLM suggested header improvements: {suggestions}")
             logger.info(f"Updated headers: {validated_header}")
-            state['final_header'] = validated_header
+            state["final_header"] = validated_header
         else:
             logger.info("LLM confirmed headers are appropriate")
-        
+
     except Exception as e:
         error_msg = f"Error validating headers: {str(e)}"
         logger.error(error_msg)
-        state['error_messages'].append(error_msg)
-    
+        state["error_messages"].append(error_msg)
+
     return state

--- a/Tabular_to_Neo4j/tests/conftest.py
+++ b/Tabular_to_Neo4j/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Dict, Any
 from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 
+
 @pytest.fixture
 def sample_csv_path():
     """Fixture that returns a path to a sample CSV file for testing."""
@@ -16,11 +17,13 @@ def sample_csv_path():
     tests_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(tests_dir, "test_data", "sample.csv")
 
+
 @pytest.fixture
 def ensure_test_data_dir(sample_csv_path):
     """Ensure the test data directory exists."""
     os.makedirs(os.path.dirname(sample_csv_path), exist_ok=True)
     return os.path.dirname(sample_csv_path)
+
 
 @pytest.fixture
 def sample_csv_content(ensure_test_data_dir, sample_csv_path):
@@ -32,65 +35,90 @@ def sample_csv_content(ensure_test_data_dir, sample_csv_path):
 4,Alice Brown,35,alice@example.com,Houston
 5,Charlie Wilson,28,charlie@example.com,Phoenix
 """
-    with open(sample_csv_path, 'w') as f:
+    with open(sample_csv_path, "w") as f:
         f.write(content)
     return sample_csv_path
+
 
 @pytest.fixture
 def sample_dataframe():
     """Fixture that returns a sample pandas DataFrame for testing."""
-    return pd.DataFrame({
-        'id': [1, 2, 3, 4, 5],
-        'name': ['John Doe', 'Jane Smith', 'Bob Johnson', 'Alice Brown', 'Charlie Wilson'],
-        'age': [30, 25, 40, 35, 28],
-        'email': ['john@example.com', 'jane@example.com', 'bob@example.com', 
-                 'alice@example.com', 'charlie@example.com'],
-        'city': ['New York', 'Los Angeles', 'Chicago', 'Houston', 'Phoenix']
-    })
+    return pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": [
+                "John Doe",
+                "Jane Smith",
+                "Bob Johnson",
+                "Alice Brown",
+                "Charlie Wilson",
+            ],
+            "age": [30, 25, 40, 35, 28],
+            "email": [
+                "john@example.com",
+                "jane@example.com",
+                "bob@example.com",
+                "alice@example.com",
+                "charlie@example.com",
+            ],
+            "city": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"],
+        }
+    )
+
 
 @pytest.fixture
 def sample_graph_state(sample_dataframe, sample_csv_path):
     """Fixture that returns a sample GraphState for testing."""
-    return GraphState({
-        'csv_file_path': sample_csv_path,
-        'raw_dataframe': sample_dataframe.copy(),
-        'processed_dataframe': sample_dataframe.copy(),
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'error_messages': []
-    })
+    return GraphState.from_dict(
+        {
+            "csv_file_path": sample_csv_path,
+            "raw_dataframe": sample_dataframe.copy(),
+            "processed_dataframe": sample_dataframe.copy(),
+            "has_header": True,
+            "detected_header": ["id", "name", "age", "email", "city"],
+            "final_header": ["id", "name", "age", "email", "city"],
+            "error_messages": [],
+        }
+    )
+
 
 @pytest.fixture
 def runnable_config():
     """Fixture that returns a sample RunnableConfig for testing."""
-    return RunnableConfig({
-        'configurable': {
-            'thread_id': 'test-thread'
-        }
-    })
+    return RunnableConfig({"configurable": {"thread_id": "test-thread"}})
+
 
 @pytest.fixture
 def mock_llm_response():
     """Fixture that provides mock LLM responses for different state names."""
+
     def _get_response(state_name: str) -> Dict[str, Any]:
         responses = {
             "infer_header": {
                 "inferred_headers": ["id", "name", "age", "email", "city"],
-                "confidence": "high"
+                "confidence": "high",
             },
             "validate_header": {
                 "validated_headers": ["id", "name", "age", "email", "city"],
                 "suggestions": [],
-                "is_valid": True
+                "is_valid": True,
             },
             "analyze_column_semantics": {
                 "column_semantics": {
-                    "id": {"type": "identifier", "description": "Unique identifier for the person"},
-                    "name": {"type": "personal_name", "description": "Full name of the person"},
+                    "id": {
+                        "type": "identifier",
+                        "description": "Unique identifier for the person",
+                    },
+                    "name": {
+                        "type": "personal_name",
+                        "description": "Full name of the person",
+                    },
                     "age": {"type": "numeric_age", "description": "Age in years"},
-                    "email": {"type": "email_address", "description": "Contact email address"},
-                    "city": {"type": "location", "description": "City of residence"}
+                    "email": {
+                        "type": "email_address",
+                        "description": "Contact email address",
+                    },
+                    "city": {"type": "location", "description": "City of residence"},
                 }
             },
             "classify_entities_properties": {
@@ -101,8 +129,8 @@ def mock_llm_response():
                     "name": "property",
                     "age": "property",
                     "email": "property",
-                    "city": "property"
-                }
+                    "city": "property",
+                },
             },
             "reconcile_entity_property": {
                 "consensus_classification": {
@@ -112,8 +140,8 @@ def mock_llm_response():
                         "name": "property",
                         "age": "property",
                         "email": "property",
-                        "city": "property"
-                    }
+                        "city": "property",
+                    },
                 }
             },
             "map_properties_to_entity": {
@@ -125,19 +153,17 @@ def mock_llm_response():
                     "name": "String",
                     "age": "Integer",
                     "email": "String",
-                    "city": "String"
-                }
+                    "city": "String",
+                },
             },
-            "infer_entity_relationships": {
-                "entity_relationships": []
-            },
+            "infer_entity_relationships": {"entity_relationships": []},
             "generate_cypher_templates": {
                 "cypher_templates": [
                     "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
                 ],
                 "constraints_and_indexes": [
                     "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
-                ]
+                ],
             },
             "synthesize_final_schema": {
                 "final_schema": {
@@ -146,8 +172,12 @@ def mock_llm_response():
                         "id": {"entity": "Person", "type": "String", "is_key": True},
                         "name": {"entity": "Person", "type": "String", "is_key": False},
                         "age": {"entity": "Person", "type": "Integer", "is_key": False},
-                        "email": {"entity": "Person", "type": "String", "is_key": False},
-                        "city": {"entity": "Person", "type": "String", "is_key": False}
+                        "email": {
+                            "entity": "Person",
+                            "type": "String",
+                            "is_key": False,
+                        },
+                        "city": {"entity": "Person", "type": "String", "is_key": False},
                     },
                     "relationships": [],
                     "cypher_templates": [
@@ -155,10 +185,10 @@ def mock_llm_response():
                     ],
                     "constraints_and_indexes": [
                         "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
-                    ]
+                    ],
                 }
-            }
+            },
         }
         return responses.get(state_name, {})
-    
+
     return _get_response

--- a/Tabular_to_Neo4j/tests/nodes/analysis/test_column_analytics.py
+++ b/Tabular_to_Neo4j/tests/nodes/analysis/test_column_analytics.py
@@ -4,102 +4,103 @@ Tests for the column analytics node.
 
 import pytest
 import pandas as pd
-from Tabular_to_Neo4j.nodes.analysis.column_analytics import perform_column_analytics_node
+from Tabular_to_Neo4j.nodes.analysis.column_analytics import (
+    perform_column_analytics_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_missing_dataframe(runnable_config):
     """Test that the perform_column_analytics_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'column_analytics' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot analyze columns" in result_state['error_messages'][0]
+    assert "column_analytics" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot analyze columns" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_success(sample_dataframe, runnable_config):
     """Test that the perform_column_analytics_node successfully analyzes columns."""
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check that the column analytics were added to the state
-    assert 'column_analytics' in result_state
-    assert isinstance(result_state['column_analytics'], dict)
-    assert len(result_state['column_analytics']) == len(sample_dataframe.columns)
-    assert result_state['error_messages'] == []
-    
+    assert "column_analytics" in result_state
+    assert isinstance(result_state["column_analytics"], dict)
+    assert len(result_state["column_analytics"]) == len(sample_dataframe.columns)
+    assert result_state["error_messages"] == []
+
     # Check that each column has the expected analytics based on the actual implementation
     for column in sample_dataframe.columns:
-        assert column in result_state['column_analytics']
-        column_stats = result_state['column_analytics'][column]
-        assert 'data_type' in column_stats
-        assert 'uniqueness_ratio' in column_stats  # The actual field name in the implementation
-        assert 'cardinality' in column_stats
-        assert 'patterns' in column_stats
-        assert 'sample_values' in column_stats
-        assert 'missing_percentage' in column_stats
+        assert column in result_state["column_analytics"]
+        column_stats = result_state["column_analytics"][column]
+        assert "data_type" in column_stats
+        assert (
+            "uniqueness_ratio" in column_stats
+        )  # The actual field name in the implementation
+        assert "cardinality" in column_stats
+        assert "patterns" in column_stats
+        assert "sample_values" in column_stats
+        assert "missing_percentage" in column_stats
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_numeric_column(runnable_config):
     """Test that the perform_column_analytics_node correctly analyzes numeric columns."""
     # Create a DataFrame with a numeric column
-    df = pd.DataFrame({
-        'numeric_column': [1, 2, 3, 4, 5, 5, 4, 3, 2, 1]
-    })
-    
+    df = pd.DataFrame({"numeric_column": [1, 2, 3, 4, 5, 5, 4, 3, 2, 1]})
+
     # Create initial state
-    initial_state = GraphState({
-        'processed_dataframe': df,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": df, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check the analytics for the numeric column based on the actual implementation
-    column_stats = result_state['column_analytics']['numeric_column']
-    assert column_stats['data_type'] == 'numeric'
-    assert column_stats['uniqueness_ratio'] == 0.5  # 5 unique values out of 10
-    assert column_stats['cardinality'] == 5  # 5 unique values
-    assert 'patterns' in column_stats
-    assert 'sample_values' in column_stats
-    assert 'missing_percentage' in column_stats
+    column_stats = result_state["column_analytics"]["numeric_column"]
+    assert column_stats["data_type"] == "numeric"
+    assert column_stats["uniqueness_ratio"] == 0.5  # 5 unique values out of 10
+    assert column_stats["cardinality"] == 5  # 5 unique values
+    assert "patterns" in column_stats
+    assert "sample_values" in column_stats
+    assert "missing_percentage" in column_stats
+
 
 @pytest.mark.unit
 def test_perform_column_analytics_node_text_column(runnable_config):
     """Test that the perform_column_analytics_node correctly analyzes text columns."""
     # Create a DataFrame with a text column
-    df = pd.DataFrame({
-        'text_column': ['apple', 'banana', 'apple', 'cherry', 'banana']
-    })
-    
+    df = pd.DataFrame({"text_column": ["apple", "banana", "apple", "cherry", "banana"]})
+
     # Create initial state
-    initial_state = GraphState({
-        'processed_dataframe': df,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"processed_dataframe": df, "error_messages": []}
+    )
+
     # Call the node
     result_state = perform_column_analytics_node(initial_state, runnable_config)
-    
+
     # Check the analytics for the text column based on the actual implementation
-    column_stats = result_state['column_analytics']['text_column']
-    assert column_stats['data_type'] == 'string'  # The actual data type used in the implementation
-    assert column_stats['uniqueness_ratio'] == 0.6  # 3 unique values out of 5
-    assert column_stats['cardinality'] == 3  # 3 unique values
-    assert 'patterns' in column_stats
-    assert 'sample_values' in column_stats
-    assert 'missing_percentage' in column_stats
+    column_stats = result_state["column_analytics"]["text_column"]
+    assert (
+        column_stats["data_type"] == "string"
+    )  # The actual data type used in the implementation
+    assert column_stats["uniqueness_ratio"] == 0.6  # 3 unique values out of 5
+    assert column_stats["cardinality"] == 3  # 3 unique values
+    assert "patterns" in column_stats
+    assert "sample_values" in column_stats
+    assert "missing_percentage" in column_stats

--- a/Tabular_to_Neo4j/tests/nodes/analysis/test_semantic_analysis.py
+++ b/Tabular_to_Neo4j/tests/nodes/analysis/test_semantic_analysis.py
@@ -4,131 +4,218 @@ Tests for the semantic analysis node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.analysis.semantic_analysis import llm_semantic_column_analysis_node
+from Tabular_to_Neo4j.nodes.analysis.semantic_analysis import (
+    llm_semantic_column_analysis_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_llm_semantic_column_analysis_node_missing_data(runnable_config):
     """Test that the llm_semantic_column_analysis_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'llm_column_semantics' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot perform semantic analysis: missing required data" in result_state['error_messages'][0]
+    assert "llm_column_semantics" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "Cannot perform semantic analysis: missing required data"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output')
-def test_llm_semantic_column_analysis_node_success(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output")
+def test_llm_semantic_column_analysis_node_success(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the llm_semantic_column_analysis_node successfully analyzes column semantics."""
     # In real-world scenarios, we need to mock both the prompt formatting and LLM response
     # This simulates a successful LLM analysis despite potential missing prompt templates
-    
+
     # Mock the format_prompt to avoid the missing template file error
     mock_format_prompt.return_value = "Analyze column semantics for the given data"
-    
+
     # Mock the LLM response with realistic column semantics
     mock_llm_response_data = {
-        'semantic_type': 'Identifier',
-        'neo4j_role': 'PRIMARY_KEY',
-        'description': 'Unique identifier for the entity',
-        'related_entity': ''
+        "semantic_type": "Identifier",
+        "neo4j_role": "PRIMARY_KEY",
+        "description": "Unique identifier for the entity",
+        "related_entity": "",
     }
     mock_call_llm.return_value = mock_llm_response_data
-    
+
     # Create initial state with DataFrame and column analytics
     # Using the actual field names from the implementation
     column_analytics = {
-        'id': {'data_type': 'numeric', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': [1, 2, 3, 4, 5], 'missing_percentage': 0.0},
-        'name': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': ['John Doe', 'Jane Smith', 'Bob Johnson', 'Alice Brown', 'Charlie Wilson'], 'missing_percentage': 0.0},
-        'age': {'data_type': 'numeric', 'uniqueness_ratio': 0.8, 'cardinality': 4, 'patterns': [], 'sample_values': [30, 25, 40, 35, 28], 'missing_percentage': 0.0},
-        'email': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': ['@'], 'sample_values': ['john@example.com', 'jane@example.com', 'bob@example.com', 'alice@example.com', 'charlie@example.com'], 'missing_percentage': 0.0},
-        'city': {'data_type': 'string', 'uniqueness_ratio': 0.8, 'cardinality': 4, 'patterns': [], 'sample_values': ['New York', 'Los Angeles', 'Chicago', 'Houston', 'Phoenix'], 'missing_percentage': 0.0}
+        "id": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [1, 2, 3, 4, 5],
+            "missing_percentage": 0.0,
+        },
+        "name": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [
+                "John Doe",
+                "Jane Smith",
+                "Bob Johnson",
+                "Alice Brown",
+                "Charlie Wilson",
+            ],
+            "missing_percentage": 0.0,
+        },
+        "age": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 0.8,
+            "cardinality": 4,
+            "patterns": [],
+            "sample_values": [30, 25, 40, 35, 28],
+            "missing_percentage": 0.0,
+        },
+        "email": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": ["@"],
+            "sample_values": [
+                "john@example.com",
+                "jane@example.com",
+                "bob@example.com",
+                "alice@example.com",
+                "charlie@example.com",
+            ],
+            "missing_percentage": 0.0,
+        },
+        "city": {
+            "data_type": "string",
+            "uniqueness_ratio": 0.8,
+            "cardinality": 4,
+            "patterns": [],
+            "sample_values": [
+                "New York",
+                "Los Angeles",
+                "Chicago",
+                "Houston",
+                "Phoenix",
+            ],
+            "missing_percentage": 0.0,
+        },
     }
-    
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe,
-        'column_analytics': column_analytics,
-        'csv_file_path': '/path/to/customers.csv',  # For primary entity inference
-        'error_messages': []
-    })
-    
+
+    initial_state = GraphState.from_dict(
+        {
+            "processed_dataframe": sample_dataframe,
+            "column_analytics": column_analytics,
+            "csv_file_path": "/path/to/customers.csv",  # For primary entity inference
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # Check that the semantic analysis results were added to the state
-    assert 'llm_column_semantics' in result_state
-    assert isinstance(result_state['llm_column_semantics'], dict)
-    assert len(result_state['llm_column_semantics']) == len(sample_dataframe.columns)
-    
+    assert "llm_column_semantics" in result_state
+    assert isinstance(result_state["llm_column_semantics"], dict)
+    assert len(result_state["llm_column_semantics"]) == len(sample_dataframe.columns)
+
     # In a real-world scenario, we'd check that the semantic analysis has the expected structure
     # rather than specific values which would depend on the LLM response
     for column in sample_dataframe.columns:
-        assert column in result_state['llm_column_semantics']
-        column_semantics = result_state['llm_column_semantics'][column]
-        assert 'semantic_type' in column_semantics
-        assert 'neo4j_role' in column_semantics
-        assert 'description' in column_semantics
-        assert 'related_entity' in column_semantics
-    
+        assert column in result_state["llm_column_semantics"]
+        column_semantics = result_state["llm_column_semantics"][column]
+        assert "semantic_type" in column_semantics
+        assert "neo4j_role" in column_semantics
+        assert "description" in column_semantics
+        assert "related_entity" in column_semantics
+
     # Verify the LLM was called the expected number of times (once per column)
     assert mock_call_llm.call_count == len(sample_dataframe.columns)
 
+
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output')
-def test_llm_semantic_column_analysis_node_llm_error(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.analysis.semantic_analysis.call_llm_with_json_output")
+def test_llm_semantic_column_analysis_node_llm_error(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the llm_semantic_column_analysis_node handles LLM errors gracefully."""
     # In real-world scenarios, LLM calls can fail for various reasons:
     # - API rate limits
     # - Network issues
     # - Invalid responses
     # This test simulates LLM failures and verifies the fallback behavior
-    
+
     # Mock the format_prompt to avoid the missing template file error
     mock_format_prompt.return_value = "Analyze column semantics for the given data"
-    
+
     # Mock the LLM to raise an exception (simulating an API failure)
     mock_call_llm.side_effect = Exception("LLM API rate limit exceeded")
-    
+
     # Create initial state with DataFrame and column analytics using the actual field names
     column_analytics = {
-        'id': {'data_type': 'numeric', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': [1, 2, 3, 4, 5], 'missing_percentage': 0.0},
-        'name': {'data_type': 'string', 'uniqueness_ratio': 1.0, 'cardinality': 5, 'patterns': [], 'sample_values': ['John Doe', 'Jane Smith'], 'missing_percentage': 0.0}
+        "id": {
+            "data_type": "numeric",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": [1, 2, 3, 4, 5],
+            "missing_percentage": 0.0,
+        },
+        "name": {
+            "data_type": "string",
+            "uniqueness_ratio": 1.0,
+            "cardinality": 5,
+            "patterns": [],
+            "sample_values": ["John Doe", "Jane Smith"],
+            "missing_percentage": 0.0,
+        },
     }
-    
-    initial_state = GraphState({
-        'processed_dataframe': sample_dataframe[['id', 'name']],  # Just use two columns for simplicity
-        'column_analytics': column_analytics,
-        'csv_file_path': '/path/to/customers.csv',
-        'error_messages': []
-    })
-    
+
+    initial_state = GraphState.from_dict(
+        {
+            "processed_dataframe": sample_dataframe[
+                ["id", "name"]
+            ],  # Just use two columns for simplicity
+            "column_analytics": column_analytics,
+            "csv_file_path": "/path/to/customers.csv",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = llm_semantic_column_analysis_node(initial_state, runnable_config)
-    
+
     # In a real-world scenario with LLM failures, the node should provide fallback classifications
     # rather than failing completely, ensuring the pipeline can continue
-    assert 'llm_column_semantics' in result_state
-    assert len(result_state['llm_column_semantics']) == 2
-    
+    assert "llm_column_semantics" in result_state
+    assert len(result_state["llm_column_semantics"]) == 2
+
     # Check that each column has fallback semantics with all expected fields
-    for column in ['id', 'name']:
-        assert column in result_state['llm_column_semantics']
-        column_semantics = result_state['llm_column_semantics'][column]
-        
+    for column in ["id", "name"]:
+        assert column in result_state["llm_column_semantics"]
+        column_semantics = result_state["llm_column_semantics"][column]
+
         # Verify the fallback values match what we'd expect in a real scenario
-        assert column_semantics['semantic_type'] == 'Unknown'
-        assert column_semantics['neo4j_role'] == 'PROPERTY'
-        assert 'Error in LLM analysis' in column_semantics['description']
-        assert 'related_entity' in column_semantics
-        
+        assert column_semantics["semantic_type"] == "Unknown"
+        assert column_semantics["neo4j_role"] == "PROPERTY"
+        assert "Error in LLM analysis" in column_semantics["description"]
+        assert "related_entity" in column_semantics
+
     # Verify that the error was properly logged but didn't stop the process
     assert mock_call_llm.call_count > 0

--- a/Tabular_to_Neo4j/tests/nodes/db_schema/test_cypher_generation.py
+++ b/Tabular_to_Neo4j/tests/nodes/db_schema/test_cypher_generation.py
@@ -5,138 +5,182 @@ Tests for the cypher generation node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.db_schema.cypher_generation import generate_cypher_templates_node
+from Tabular_to_Neo4j.nodes.db_schema.cypher_generation import (
+    generate_cypher_templates_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_generate_cypher_templates_node_missing_data(runnable_config):
     """Test that the generate_cypher_templates_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot generate Cypher templates" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot generate Cypher templates" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node successfully generates Cypher templates."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-        'constraint_queries': ['CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'],
-        'index_queries': ['CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)'],
-        'example_queries': ['MATCH (p:Person) RETURN p']
+        "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+        "constraint_queries": [
+            "CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+        ],
+        "index_queries": [
+            "CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)"
+        ],
+        "example_queries": ["MATCH (p:Person) RETURN p"],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that the Cypher templates were added to the state
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'constraint_queries' in result_state['cypher_query_templates']
-    assert 'index_queries' in result_state['cypher_query_templates']
-    assert 'example_queries' in result_state['cypher_query_templates']
-    assert 'LOAD CSV' in result_state['cypher_query_templates']['load_query']
-    assert len(result_state['cypher_query_templates']['constraint_queries']) == 1
-    assert len(result_state['cypher_query_templates']['index_queries']) == 1
-    assert len(result_state['cypher_query_templates']['example_queries']) == 1
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "constraint_queries" in result_state["cypher_query_templates"]
+    assert "index_queries" in result_state["cypher_query_templates"]
+    assert "example_queries" in result_state["cypher_query_templates"]
+    assert "LOAD CSV" in result_state["cypher_query_templates"]["load_query"]
+    assert len(result_state["cypher_query_templates"]["constraint_queries"]) == 1
+    assert len(result_state["cypher_query_templates"]["index_queries"]) == 1
+    assert len(result_state["cypher_query_templates"]["example_queries"]) == 1
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_empty_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_empty_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node handles empty LLM responses."""
     # Mock empty LLM response
     mock_call_llm.return_value = {
-        'load_query': '',
-        'constraint_queries': [],
-        'index_queries': [],
-        'example_queries': []
+        "load_query": "",
+        "constraint_queries": [],
+        "index_queries": [],
+        "example_queries": [],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that fallback templates were created
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'LOAD CSV' in result_state['cypher_query_templates']['load_query']
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "LOAD CSV" in result_state["cypher_query_templates"]["load_query"]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output')
-def test_generate_cypher_templates_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.cypher_generation.call_llm_with_json_output")
+def test_generate_cypher_templates_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the generate_cypher_templates_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+        }
+    )
+
     # Call the node
     result_state = generate_cypher_templates_node(initial_state, runnable_config)
-    
+
     # Check that fallback templates were created
-    assert 'cypher_query_templates' in result_state
-    assert 'load_query' in result_state['cypher_query_templates']
-    assert 'Error generating Cypher templates' in result_state['error_messages'][0]
+    assert "cypher_query_templates" in result_state
+    assert "load_query" in result_state["cypher_query_templates"]
+    assert "Error generating Cypher templates" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/db_schema/test_schema_finalization.py
+++ b/Tabular_to_Neo4j/tests/nodes/db_schema/test_schema_finalization.py
@@ -5,212 +5,252 @@ Tests for the schema finalization node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.db_schema.schema_finalization import synthesize_final_schema_node
+from Tabular_to_Neo4j.nodes.db_schema.schema_finalization import (
+    synthesize_final_schema_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_synthesize_final_schema_node_missing_data(runnable_config):
     """Test that the synthesize_final_schema_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot synthesize final schema" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot synthesize final schema" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node successfully synthesizes the final schema."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'node_labels': [
+        "node_labels": [
             {
-                'label': 'Person',
-                'description': 'Represents a person',
-                'is_primary': True
+                "label": "Person",
+                "description": "Represents a person",
+                "is_primary": True,
             }
         ],
-        'relationship_types': [
+        "relationship_types": [
             {
-                'type': 'LIVES_IN',
-                'source_label': 'Person',
-                'target_label': 'City',
-                'description': 'Indicates where a person lives',
-                'cardinality': 'MANY_TO_ONE'
+                "type": "LIVES_IN",
+                "source_label": "Person",
+                "target_label": "City",
+                "description": "Indicates where a person lives",
+                "cardinality": "MANY_TO_ONE",
             }
         ],
-        'property_keys': [
+        "property_keys": [
             {
-                'key': 'id',
-                'data_type': 'STRING',
-                'description': 'Unique identifier for a person',
-                'belongs_to': 'Person',
-                'is_identifier': True
+                "key": "id",
+                "data_type": "STRING",
+                "description": "Unique identifier for a person",
+                "belongs_to": "Person",
+                "is_identifier": True,
             },
             {
-                'key': 'name',
-                'data_type': 'STRING',
-                'description': 'Name of a person',
-                'belongs_to': 'Person',
-                'is_identifier': False
+                "key": "name",
+                "data_type": "STRING",
+                "description": "Name of a person",
+                "belongs_to": "Person",
+                "is_identifier": False,
+            },
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "entity_type": "Person",
+                "property_key": "id",
+                "description": "Ensures person id is unique",
             }
         ],
-        'constraints': [
+        "indexes": [
             {
-                'type': 'UNIQUENESS',
-                'entity_type': 'Person',
-                'property_key': 'id',
-                'description': 'Ensures person id is unique'
+                "type": "BTREE",
+                "entity_type": "Person",
+                "property_key": "name",
+                "description": "Index for faster name lookups",
             }
         ],
-        'indexes': [
-            {
-                'type': 'BTREE',
-                'entity_type': 'Person',
-                'property_key': 'name',
-                'description': 'Index for faster name lookups'
-            }
-        ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': [
-            {
-                'source_entity': 'Person',
-                'relationship_type': 'LIVES_IN',
-                'target_entity': 'City',
-                'properties': [],
-                'cardinality': 'MANY_TO_ONE'
-            }
-        ],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-            'constraint_queries': ['CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'],
-            'index_queries': ['CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)'],
-            'example_queries': ['MATCH (p:Person) RETURN p']
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [
+                {
+                    "source_entity": "Person",
+                    "relationship_type": "LIVES_IN",
+                    "target_entity": "City",
+                    "properties": [],
+                    "cardinality": "MANY_TO_ONE",
+                }
+            ],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+                "constraint_queries": [
+                    "CREATE CONSTRAINT person_id_unique IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+                ],
+                "index_queries": [
+                    "CREATE INDEX person_name_index IF NOT EXISTS FOR (p:Person) ON (p.name)"
+                ],
+                "example_queries": ["MATCH (p:Person) RETURN p"],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that the final schema was added to the state
-    assert 'inferred_neo4j_schema' in result_state
-    assert 'node_labels' in result_state['inferred_neo4j_schema']
-    assert 'relationship_types' in result_state['inferred_neo4j_schema']
-    assert 'property_keys' in result_state['inferred_neo4j_schema']
-    assert 'constraints' in result_state['inferred_neo4j_schema']
-    assert 'indexes' in result_state['inferred_neo4j_schema']
-    assert 'cypher_templates' in result_state['inferred_neo4j_schema']
-    assert len(result_state['inferred_neo4j_schema']['node_labels']) == 1
-    assert len(result_state['inferred_neo4j_schema']['relationship_types']) == 1
-    assert len(result_state['inferred_neo4j_schema']['property_keys']) == 2
-    assert len(result_state['inferred_neo4j_schema']['constraints']) == 1
-    assert len(result_state['inferred_neo4j_schema']['indexes']) == 1
+    assert "inferred_neo4j_schema" in result_state
+    assert "node_labels" in result_state["inferred_neo4j_schema"]
+    assert "relationship_types" in result_state["inferred_neo4j_schema"]
+    assert "property_keys" in result_state["inferred_neo4j_schema"]
+    assert "constraints" in result_state["inferred_neo4j_schema"]
+    assert "indexes" in result_state["inferred_neo4j_schema"]
+    assert "cypher_templates" in result_state["inferred_neo4j_schema"]
+    assert len(result_state["inferred_neo4j_schema"]["node_labels"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["relationship_types"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["property_keys"]) == 2
+    assert len(result_state["inferred_neo4j_schema"]["constraints"]) == 1
+    assert len(result_state["inferred_neo4j_schema"]["indexes"]) == 1
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_empty_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_empty_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node handles empty LLM responses."""
     # Mock empty LLM response
     mock_call_llm.return_value = {
-        'node_labels': [],
-        'relationship_types': [],
-        'property_keys': [],
-        'constraints': [],
-        'indexes': []
+        "node_labels": [],
+        "relationship_types": [],
+        "property_keys": [],
+        "constraints": [],
+        "indexes": [],
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
-            }
-        },
-        'entity_relationships': [],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
-            'constraint_queries': [],
-            'index_queries': [],
-            'example_queries': []
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                }
+            },
+            "entity_relationships": [],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id, name: row.name})',
+                "constraint_queries": [],
+                "index_queries": [],
+                "example_queries": [],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that fallback schema was created
-    assert 'inferred_neo4j_schema' in result_state
-    assert len(result_state['inferred_neo4j_schema']['node_labels']) > 0
-    assert len(result_state['inferred_neo4j_schema']['property_keys']) > 0
+    assert "inferred_neo4j_schema" in result_state
+    assert len(result_state["inferred_neo4j_schema"]["node_labels"]) > 0
+    assert len(result_state["inferred_neo4j_schema"]["property_keys"]) > 0
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output')
-def test_synthesize_final_schema_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.format_prompt")
+@patch("Tabular_to_Neo4j.nodes.db_schema.schema_finalization.call_llm_with_json_output")
+def test_synthesize_final_schema_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the synthesize_final_schema_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
-            }
-        },
-        'entity_relationships': [],
-        'cypher_query_templates': {
-            'load_query': 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id})',
-            'constraint_queries': [],
-            'index_queries': [],
-            'example_queries': []
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                }
+            },
+            "entity_relationships": [],
+            "cypher_query_templates": {
+                "load_query": 'LOAD CSV WITH HEADERS FROM "file:///people.csv" AS row CREATE (p:Person {id: row.id})',
+                "constraint_queries": [],
+                "index_queries": [],
+                "example_queries": [],
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = synthesize_final_schema_node(initial_state, runnable_config)
-    
+
     # Check that fallback schema was created
-    assert 'inferred_neo4j_schema' in result_state
-    assert 'node_labels' in result_state['inferred_neo4j_schema']
-    assert 'property_keys' in result_state['inferred_neo4j_schema']
-    assert 'Error synthesizing final schema' in result_state['error_messages'][0]
+    assert "inferred_neo4j_schema" in result_state
+    assert "node_labels" in result_state["inferred_neo4j_schema"]
+    assert "property_keys" in result_state["inferred_neo4j_schema"]
+    assert "Error synthesizing final schema" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_classification.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_classification.py
@@ -4,97 +4,120 @@ Tests for the entity classification node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.entity_inference.entity_classification import classify_entities_properties_node
+from Tabular_to_Neo4j.nodes.entity_inference.entity_classification import (
+    classify_entities_properties_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_classify_entities_properties_node_missing_data(runnable_config):
     """Test that the classify_entities_properties_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot classify entities/properties" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot classify entities/properties" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output')
-def test_classify_entities_properties_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output"
+)
+def test_classify_entities_properties_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the classify_entities_properties_node successfully classifies entities and properties."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'classification': 'entity',
-        'entity_type': 'Person',
-        'relationship_to_primary': 'IS_A',
-        'property_name': 'person_id',
-        'reasoning': 'This is a unique identifier for a person.'
+        "classification": "entity",
+        "entity_type": "Person",
+        "relationship_to_primary": "IS_A",
+        "property_name": "person_id",
+        "reasoning": "This is a unique identifier for a person.",
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'final_header': ['id', 'name', 'age'],
-        'column_analytics': {
-            'id': {'uniqueness': 1.0, 'cardinality': 100, 'data_type': 'integer'},
-            'name': {'uniqueness': 0.9, 'cardinality': 90, 'data_type': 'string'},
-            'age': {'uniqueness': 0.1, 'cardinality': 10, 'data_type': 'integer'}
-        },
-        'llm_column_semantics': {
-            'id': {'semantic_type': 'identifier', 'neo4j_role': 'ID'},
-            'name': {'semantic_type': 'name', 'neo4j_role': 'PROPERTY'},
-            'age': {'semantic_type': 'age', 'neo4j_role': 'PROPERTY'}
-        },
-        'processed_dataframe': None
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "final_header": ["id", "name", "age"],
+            "column_analytics": {
+                "id": {"uniqueness": 1.0, "cardinality": 100, "data_type": "integer"},
+                "name": {"uniqueness": 0.9, "cardinality": 90, "data_type": "string"},
+                "age": {"uniqueness": 0.1, "cardinality": 10, "data_type": "integer"},
+            },
+            "llm_column_semantics": {
+                "id": {"semantic_type": "identifier", "neo4j_role": "ID"},
+                "name": {"semantic_type": "name", "neo4j_role": "PROPERTY"},
+                "age": {"semantic_type": "age", "neo4j_role": "PROPERTY"},
+            },
+            "processed_dataframe": None,
+        }
+    )
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that the classification was added to the state
-    assert 'entity_property_classification' in result_state
-    assert len(result_state['entity_property_classification']) == 3
-    assert result_state['entity_property_classification']['id']['classification'] == 'entity'
-    assert result_state['entity_property_classification']['id']['entity_type'] == 'Person'
+    assert "entity_property_classification" in result_state
+    assert len(result_state["entity_property_classification"]) == 3
+    assert (
+        result_state["entity_property_classification"]["id"]["classification"]
+        == "entity"
+    )
+    assert (
+        result_state["entity_property_classification"]["id"]["entity_type"] == "Person"
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output')
-def test_classify_entities_properties_node_llm_error(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.entity_classification.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.entity_classification.call_llm_with_json_output"
+)
+def test_classify_entities_properties_node_llm_error(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the classify_entities_properties_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'final_header': ['id', 'name', 'age'],
-        'column_analytics': {
-            'id': {'uniqueness': 1.0, 'cardinality': 100, 'data_type': 'integer'},
-            'name': {'uniqueness': 0.9, 'cardinality': 90, 'data_type': 'string'},
-            'age': {'uniqueness': 0.1, 'cardinality': 10, 'data_type': 'integer'}
-        },
-        'llm_column_semantics': {
-            'id': {'semantic_type': 'identifier', 'neo4j_role': 'ID'},
-            'name': {'semantic_type': 'name', 'neo4j_role': 'PROPERTY'},
-            'age': {'semantic_type': 'age', 'neo4j_role': 'PROPERTY'}
-        },
-        'processed_dataframe': None
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "final_header": ["id", "name", "age"],
+            "column_analytics": {
+                "id": {"uniqueness": 1.0, "cardinality": 100, "data_type": "integer"},
+                "name": {"uniqueness": 0.9, "cardinality": 90, "data_type": "string"},
+                "age": {"uniqueness": 0.1, "cardinality": 10, "data_type": "integer"},
+            },
+            "llm_column_semantics": {
+                "id": {"semantic_type": "identifier", "neo4j_role": "ID"},
+                "name": {"semantic_type": "name", "neo4j_role": "PROPERTY"},
+                "age": {"semantic_type": "age", "neo4j_role": "PROPERTY"},
+            },
+            "processed_dataframe": None,
+        }
+    )
+
     # Call the node
     result_state = classify_entities_properties_node(initial_state, runnable_config)
-    
+
     # Check that the classification was added to the state with fallback values
-    assert 'entity_property_classification' in result_state
-    assert len(result_state['entity_property_classification']) == 3
-    assert 'LLM entity classification failed' in result_state['error_messages'][0]
+    assert "entity_property_classification" in result_state
+    assert len(result_state["entity_property_classification"]) == 3
+    assert "LLM entity classification failed" in result_state["error_messages"][0]
     # Check that a fallback classification was used
-    assert result_state['entity_property_classification']['id']['classification'] in ['entity', 'property']
+    assert result_state["entity_property_classification"]["id"]["classification"] in [
+        "entity",
+        "property",
+    ]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_reconciliation.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_entity_reconciliation.py
@@ -5,61 +5,68 @@ Tests for the entity reconciliation node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.entity_reconciliation import reconcile_entity_property_node
+from Tabular_to_Neo4j.nodes.entity_inference.entity_reconciliation import (
+    reconcile_entity_property_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_reconcile_entity_property_node_missing_data(runnable_config):
     """Test that the reconcile_entity_property_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = reconcile_entity_property_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot reconcile entity/property classifications" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "Cannot reconcile entity/property classifications"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
 def test_reconcile_entity_property_node_success(runnable_config):
     """Test that the reconcile_entity_property_node successfully reconciles entity and property classifications."""
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_classification': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'property_name': 'id',
-                'reasoning': 'This is a unique identifier for a person.',
-                'analytics': {'uniqueness': 1.0},
-                'semantics': {'semantic_type': 'identifier'}
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_classification": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "property_name": "id",
+                    "reasoning": "This is a unique identifier for a person.",
+                    "analytics": {"uniqueness": 1.0},
+                    "semantics": {"semantic_type": "identifier"},
+                },
+                "name": {
+                    "column_name": "name",
+                    "classification": "entity_property",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "property_name": "name",
+                    "reasoning": "This is a property of a person.",
+                    "analytics": {"uniqueness": 0.9},
+                    "semantics": {"semantic_type": "name"},
+                },
             },
-            'name': {
-                'column_name': 'name',
-                'classification': 'entity_property',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'property_name': 'name',
-                'reasoning': 'This is a property of a person.',
-                'analytics': {'uniqueness': 0.9},
-                'semantics': {'semantic_type': 'name'}
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = reconcile_entity_property_node(initial_state, runnable_config)
-    
+
     # Check that the consensus was added to the state
-    assert 'entity_property_consensus' in result_state
-    assert len(result_state['entity_property_consensus']) == 2
-    assert 'id' in result_state['entity_property_consensus']
-    assert 'name' in result_state['entity_property_consensus']
+    assert "entity_property_consensus" in result_state
+    assert len(result_state["entity_property_consensus"]) == 2
+    assert "id" in result_state["entity_property_consensus"]
+    assert "name" in result_state["entity_property_consensus"]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_property_mapping.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_property_mapping.py
@@ -5,113 +5,118 @@ Tests for the property mapping node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.property_mapping import map_properties_to_entities_node
+from Tabular_to_Neo4j.nodes.entity_inference.property_mapping import (
+    map_properties_to_entities_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_map_properties_to_entities_node_missing_data(runnable_config):
     """Test that the map_properties_to_entities_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot map properties to entities" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot map properties to entities" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output')
-def test_map_properties_to_entities_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.property_mapping.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output"
+)
+def test_map_properties_to_entities_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the map_properties_to_entities_node successfully maps properties to entities."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'properties': [
-            {
-                'column_name': 'id',
-                'property_key': 'id',
-                'is_identifier': True
-            },
-            {
-                'column_name': 'name',
-                'property_key': 'name',
-                'is_identifier': False
-            }
+        "properties": [
+            {"column_name": "id", "property_key": "id", "is_identifier": True},
+            {"column_name": "name", "property_key": "name", "is_identifier": False},
         ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_consensus': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'id',
-                'semantic_type': 'identifier',
-                'confidence': 0.9,
-                'reasoning': 'This is a unique identifier for a person.'
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_consensus": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "id",
+                    "semantic_type": "identifier",
+                    "confidence": 0.9,
+                    "reasoning": "This is a unique identifier for a person.",
+                },
+                "name": {
+                    "column_name": "name",
+                    "classification": "entity_property",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "name",
+                    "semantic_type": "name",
+                    "confidence": 0.8,
+                    "reasoning": "This is a property of a person.",
+                },
             },
-            'name': {
-                'column_name': 'name',
-                'classification': 'entity_property',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'name',
-                'semantic_type': 'name',
-                'confidence': 0.8,
-                'reasoning': 'This is a property of a person.'
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that the mapping was added to the state
-    assert 'property_entity_mapping' in result_state
-    assert 'Person' in result_state['property_entity_mapping']
-    assert result_state['property_entity_mapping']['Person']['type'] == 'entity'
-    assert len(result_state['property_entity_mapping']['Person']['properties']) == 2
+    assert "property_entity_mapping" in result_state
+    assert "Person" in result_state["property_entity_mapping"]
+    assert result_state["property_entity_mapping"]["Person"]["type"] == "entity"
+    assert len(result_state["property_entity_mapping"]["Person"]["properties"]) == 2
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output')
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.property_mapping.call_llm_with_json_output"
+)
 def test_map_properties_to_entities_node_llm_error(mock_call_llm, runnable_config):
     """Test that the map_properties_to_entities_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'entity_property_consensus': {
-            'id': {
-                'column_name': 'id',
-                'classification': 'entity_identifier',
-                'entity_type': 'Person',
-                'relationship_to_primary': '',
-                'neo4j_property_key': 'id',
-                'semantic_type': 'identifier',
-                'confidence': 0.9,
-                'reasoning': 'This is a unique identifier for a person.'
-            }
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "entity_property_consensus": {
+                "id": {
+                    "column_name": "id",
+                    "classification": "entity_identifier",
+                    "entity_type": "Person",
+                    "relationship_to_primary": "",
+                    "neo4j_property_key": "id",
+                    "semantic_type": "identifier",
+                    "confidence": 0.9,
+                    "reasoning": "This is a unique identifier for a person.",
+                }
+            },
         }
-    })
-    
+    )
+
     # Call the node
     result_state = map_properties_to_entities_node(initial_state, runnable_config)
-    
+
     # Check that the mapping was added to the state with fallback values
-    assert 'property_entity_mapping' in result_state
-    assert 'Person' in result_state['property_entity_mapping']
-    assert result_state['property_entity_mapping']['Person']['type'] == 'entity'
-    assert len(result_state['property_entity_mapping']['Person']['properties']) == 1
-    assert 'Error mapping properties for entity' in result_state['error_messages'][0]
+    assert "property_entity_mapping" in result_state
+    assert "Person" in result_state["property_entity_mapping"]
+    assert result_state["property_entity_mapping"]["Person"]["type"] == "entity"
+    assert len(result_state["property_entity_mapping"]["Person"]["properties"]) == 1
+    assert "Error mapping properties for entity" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/entity_inference/test_relationship_inference.py
+++ b/Tabular_to_Neo4j/tests/nodes/entity_inference/test_relationship_inference.py
@@ -5,157 +5,207 @@ Tests for the relationship inference node.
 import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
-from Tabular_to_Neo4j.nodes.entity_inference.relationship_inference import infer_entity_relationships_node
+from Tabular_to_Neo4j.nodes.entity_inference.relationship_inference import (
+    infer_entity_relationships_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_infer_entity_relationships_node_missing_data(runnable_config):
     """Test that the infer_entity_relationships_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot infer entity relationships" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot infer entity relationships" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
-def test_infer_entity_relationships_node_success(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
+def test_infer_entity_relationships_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the infer_entity_relationships_node successfully infers relationships."""
     # Mock LLM response
     mock_call_llm.return_value = {
-        'relationships': [
+        "relationships": [
             {
-                'source_entity': 'Person',
-                'relationship_type': 'LIVES_IN',
-                'target_entity': 'City',
-                'properties': [],
-                'cardinality': 'MANY_TO_ONE'
+                "source_entity": "Person",
+                "relationship_type": "LIVES_IN",
+                "target_entity": "City",
+                "properties": [],
+                "cardinality": "MANY_TO_ONE",
             }
         ]
     }
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True},
-                    {'column_name': 'name', 'property_key': 'name', 'is_identifier': False}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "name",
+                            "property_key": "name",
+                            "is_identifier": False,
+                        },
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        },
+                        {
+                            "column_name": "city_name",
+                            "property_key": "cityName",
+                            "is_identifier": False,
+                        },
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True},
-                    {'column_name': 'city_name', 'property_key': 'cityName', 'is_identifier': False}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that the relationships were added to the state
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) == 1
-    assert result_state['entity_relationships'][0]['source_entity'] == 'Person'
-    assert result_state['entity_relationships'][0]['relationship_type'] == 'LIVES_IN'
-    assert result_state['entity_relationships'][0]['target_entity'] == 'City'
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) == 1
+    assert result_state["entity_relationships"][0]["source_entity"] == "Person"
+    assert result_state["entity_relationships"][0]["relationship_type"] == "LIVES_IN"
+    assert result_state["entity_relationships"][0]["target_entity"] == "City"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
 def test_infer_entity_relationships_node_llm_error(mock_call_llm, runnable_config):
     """Test that the infer_entity_relationships_node handles LLM errors."""
     # Mock LLM error
     mock_call_llm.side_effect = Exception("LLM error")
-    
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that default relationships were created
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) > 0
-    assert 'LLM relationship inference failed' in result_state['error_messages'][0]
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) > 0
+    assert "LLM relationship inference failed" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output')
-def test_infer_entity_relationships_node_no_relationships(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.entity_inference.relationship_inference.call_llm_with_json_output"
+)
+def test_infer_entity_relationships_node_no_relationships(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the infer_entity_relationships_node creates default relationships when none are inferred."""
     # Mock LLM response with no relationships
-    mock_call_llm.return_value = {
-        'relationships': []
-    }
-    
+    mock_call_llm.return_value = {"relationships": []}
+
     # Create initial state with required data
-    initial_state = GraphState({
-        'error_messages': [],
-        'csv_file_path': '/path/to/people.csv',
-        'property_entity_mapping': {
-            'Person': {
-                'type': 'entity',
-                'entity_type': 'Person',
-                'is_primary': True,
-                'properties': [
-                    {'column_name': 'id', 'property_key': 'id', 'is_identifier': True}
-                ]
+    initial_state = GraphState.from_dict(
+        {
+            "error_messages": [],
+            "csv_file_path": "/path/to/people.csv",
+            "property_entity_mapping": {
+                "Person": {
+                    "type": "entity",
+                    "entity_type": "Person",
+                    "is_primary": True,
+                    "properties": [
+                        {
+                            "column_name": "id",
+                            "property_key": "id",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
+                "City": {
+                    "type": "entity",
+                    "entity_type": "City",
+                    "is_primary": False,
+                    "properties": [
+                        {
+                            "column_name": "city_id",
+                            "property_key": "cityId",
+                            "is_identifier": True,
+                        }
+                    ],
+                },
             },
-            'City': {
-                'type': 'entity',
-                'entity_type': 'City',
-                'is_primary': False,
-                'properties': [
-                    {'column_name': 'city_id', 'property_key': 'cityId', 'is_identifier': True}
-                ]
-            }
         }
-    })
-    
+    )
+
     # Call the node
     result_state = infer_entity_relationships_node(initial_state, runnable_config)
-    
+
     # Check that default relationships were created
-    assert 'entity_relationships' in result_state
-    assert len(result_state['entity_relationships']) > 0
-    assert result_state['entity_relationships'][0]['source_entity'] == 'Person'
-    assert 'HAS_CITY' in result_state['entity_relationships'][0]['relationship_type']
-    assert result_state['entity_relationships'][0]['target_entity'] == 'City'
+    assert "entity_relationships" in result_state
+    assert len(result_state["entity_relationships"]) > 0
+    assert result_state["entity_relationships"][0]["source_entity"] == "Person"
+    assert "HAS_CITY" in result_state["entity_relationships"][0]["relationship_type"]
+    assert result_state["entity_relationships"][0]["target_entity"] == "City"

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_inference.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_inference.py
@@ -4,101 +4,124 @@ Tests for the header inference node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_inference import infer_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_inference import (
+    infer_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_infer_header_llm_node_no_dataframe(runnable_config):
     """Test that the infer_header_llm_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot infer header" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot infer header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_success(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_success(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the infer_header_llm_node successfully infers headers."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM response
     mock_call_llm.return_value = list(sample_dataframe.columns)
-    
+
     # Create initial state with a DataFrame but no headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were inferred
-    assert 'inferred_header' in result_state
-    assert result_state['inferred_header'] == list(sample_dataframe.columns)
-    assert result_state['final_header'] == list(sample_dataframe.columns)
-    assert result_state['error_messages'] == []
-    
+    assert "inferred_header" in result_state
+    assert result_state["inferred_header"] == list(sample_dataframe.columns)
+    assert result_state["final_header"] == list(sample_dataframe.columns)
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "infer_header"
+    assert mock_call_llm.call_args[1]["state_name"] == "infer_header"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the infer_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM to return an invalid response (not a list)
     mock_call_llm.return_value = {"error": "Not a list of headers"}
-    
+
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of headers" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM did not return a list of headers" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output')
-def test_infer_header_llm_node_wrong_length(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_inference.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_inference.call_llm_with_json_output"
+)
+def test_infer_header_llm_node_wrong_length(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the infer_header_llm_node handles LLM responses with wrong number of headers."""
     # Mock the format_prompt to avoid missing template file errors
-    mock_format_prompt.return_value = "Infer headers for the following data: {data_sample}"
+    mock_format_prompt.return_value = (
+        "Infer headers for the following data: {data_sample}"
+    )
     # Mock the LLM to return a list with wrong number of headers
     mock_call_llm.return_value = ["header1", "header2"]  # Not enough headers
-    
+
     # Create initial state with a DataFrame
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"raw_dataframe": sample_dataframe, "error_messages": []}
+    )
+
     # Call the node
     result_state = infer_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'inferred_header' not in result_state
-    assert 'final_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM returned 2 headers, but CSV has" in result_state['error_messages'][0]
+    assert "inferred_header" not in result_state
+    assert "final_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM returned 2 headers, but CSV has" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_translation.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_translation.py
@@ -4,102 +4,142 @@ Tests for the header translation node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_translation import translate_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_translation import (
+    translate_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_translate_header_llm_node_missing_header(runnable_config):
     """Test that the translate_header_llm_node handles missing header."""
     # Create initial state without a header
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot translate header" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot translate header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_success(mock_call_llm, mock_format_prompt, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_success(
+    mock_call_llm, mock_format_prompt, runnable_config, mock_llm_response
+):
     """Test that the translate_header_llm_node successfully translates headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM response
-    mock_call_llm.return_value = ["id", "name", "age", "email", "city"]  # Translated headers
-    
+    mock_call_llm.return_value = [
+        "id",
+        "name",
+        "age",
+        "email",
+        "city",
+    ]  # Translated headers
+
     # Create initial state with headers and language info
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],  # Spanish headers
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": [
+                "id",
+                "nombre",
+                "edad",
+                "correo",
+                "ciudad",
+            ],  # Spanish headers
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were translated
-    assert 'translated_header' in result_state
-    assert result_state['translated_header'] == ["id", "name", "age", "email", "city"]
-    assert result_state['final_header'] == ["id", "name", "age", "email", "city"]
-    assert result_state['error_messages'] == []
-    
+    assert "translated_header" in result_state
+    assert result_state["translated_header"] == ["id", "name", "age", "email", "city"]
+    assert result_state["final_header"] == ["id", "name", "age", "email", "city"]
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name and is_translation flag
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "translate_header"
-    assert mock_call_llm.call_args[1]['is_translation'] is True
+    assert mock_call_llm.call_args[1]["state_name"] == "translate_header"
+    assert mock_call_llm.call_args[1]["is_translation"] is True
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the translate_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM to return an invalid response (not a list)
     mock_call_llm.return_value = {"error": "Not a list of headers"}
-    
+
     # Create initial state with headers
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": ["id", "nombre", "edad", "correo", "ciudad"],
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of translated headers" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "LLM did not return a list of translated headers"
+        in result_state["error_messages"][0]
+    )
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output')
-def test_translate_header_llm_node_wrong_length(mock_call_llm, mock_format_prompt, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_translation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_translation.call_llm_with_json_output"
+)
+def test_translate_header_llm_node_wrong_length(
+    mock_call_llm, mock_format_prompt, runnable_config
+):
     """Test that the translate_header_llm_node handles LLM responses with wrong number of headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Translate the following headers from {header_language} to English: {original_header}"
     # Mock the LLM to return a list with wrong number of headers
     mock_call_llm.return_value = ["id", "name", "age"]  # Missing two headers
-    
+
     # Create initial state with headers
-    initial_state = GraphState({
-        'final_header': ["id", "nombre", "edad", "correo", "ciudad"],
-        'header_language': "Spanish",
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "final_header": ["id", "nombre", "edad", "correo", "ciudad"],
+            "header_language": "Spanish",
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = translate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'translated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM returned 3 headers, but original has 5 columns" in result_state['error_messages'][0]
+    assert "translated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert (
+        "LLM returned 3 headers, but original has 5 columns"
+        in result_state["error_messages"][0]
+    )

--- a/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_validation.py
+++ b/Tabular_to_Neo4j/tests/nodes/header_processing/test_header_validation.py
@@ -4,29 +4,39 @@ Tests for the header validation node.
 
 import pytest
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.header_processing.header_validation import validate_header_llm_node
+from Tabular_to_Neo4j.nodes.header_processing.header_validation import (
+    validate_header_llm_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_validate_header_llm_node_missing_data(runnable_config):
     """Test that the validate_header_llm_node handles missing data."""
     # Create initial state without required data
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'validated_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot validate header" in result_state['error_messages'][0]
+    assert "validated_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot validate header" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_correct_headers(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config, mock_llm_response):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_correct_headers(
+    mock_call_llm,
+    mock_format_prompt,
+    sample_dataframe,
+    runnable_config,
+    mock_llm_response,
+):
     """Test that the validate_header_llm_node handles correct headers."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
@@ -34,63 +44,97 @@ def test_validate_header_llm_node_correct_headers(mock_call_llm, mock_format_pro
     mock_call_llm.return_value = {
         "is_correct": True,
         "validated_header": list(sample_dataframe.columns),
-        "suggestions": ""
+        "suggestions": "",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were validated
-    assert 'validated_header' in result_state
-    assert result_state['validated_header'] == list(sample_dataframe.columns)
-    assert result_state['final_header'] == list(sample_dataframe.columns)  # Unchanged since headers are correct
-    assert result_state['error_messages'] == []
-    
+    assert "validated_header" in result_state
+    assert result_state["validated_header"] == list(sample_dataframe.columns)
+    assert result_state["final_header"] == list(
+        sample_dataframe.columns
+    )  # Unchanged since headers are correct
+    assert result_state["error_messages"] == []
+
     # Verify the LLM was called with the correct state name
     mock_call_llm.assert_called_once()
-    assert mock_call_llm.call_args[1]['state_name'] == "validate_header"
+    assert mock_call_llm.call_args[1]["state_name"] == "validate_header"
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_improved_headers(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_improved_headers(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the validate_header_llm_node improves headers when needed."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
     # Mock the LLM response to indicate headers need improvement
     mock_call_llm.return_value = {
         "is_correct": False,
-        "validated_header": ["identifier", "full_name", "years", "email_address", "location"],
-        "suggestions": "Made headers more descriptive"
+        "validated_header": [
+            "identifier",
+            "full_name",
+            "years",
+            "email_address",
+            "location",
+        ],
+        "suggestions": "Made headers more descriptive",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that the headers were improved
-    assert 'validated_header' in result_state
-    assert result_state['validated_header'] == ["identifier", "full_name", "years", "email_address", "location"]
-    assert result_state['final_header'] == ["identifier", "full_name", "years", "email_address", "location"]
-    assert result_state['error_messages'] == []
+    assert "validated_header" in result_state
+    assert result_state["validated_header"] == [
+        "identifier",
+        "full_name",
+        "years",
+        "email_address",
+        "location",
+    ]
+    assert result_state["final_header"] == [
+        "identifier",
+        "full_name",
+        "years",
+        "email_address",
+        "location",
+    ]
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt')
-@patch('Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output')
-def test_validate_header_llm_node_invalid_response(mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config):
+@patch("Tabular_to_Neo4j.nodes.header_processing.header_validation.format_prompt")
+@patch(
+    "Tabular_to_Neo4j.nodes.header_processing.header_validation.call_llm_with_json_output"
+)
+def test_validate_header_llm_node_invalid_response(
+    mock_call_llm, mock_format_prompt, sample_dataframe, runnable_config
+):
     """Test that the validate_header_llm_node handles invalid LLM responses."""
     # Mock the format_prompt to avoid missing template file errors
     mock_format_prompt.return_value = "Validate the following headers: {current_header}"
@@ -98,19 +142,21 @@ def test_validate_header_llm_node_invalid_response(mock_call_llm, mock_format_pr
     mock_call_llm.return_value = {
         "is_correct": False,
         "validated_header": "Not a list",  # Should be a list
-        "suggestions": "Made headers more descriptive"
+        "suggestions": "Made headers more descriptive",
     }
-    
+
     # Create initial state with DataFrame and headers
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'final_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "final_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = validate_header_llm_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert len(result_state['error_messages']) > 0
-    assert "LLM did not return a list of headers" in result_state['error_messages'][0]
+    assert len(result_state["error_messages"]) > 0
+    assert "LLM did not return a list of headers" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/nodes/input/test_csv_loader.py
+++ b/Tabular_to_Neo4j/tests/nodes/input/test_csv_loader.py
@@ -10,56 +10,61 @@ from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 from Tabular_to_Neo4j.nodes.input.csv_loader import load_csv_node
 
+
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_success(mock_load_csv, sample_csv_content, runnable_config):
     """Test that the load_csv_node successfully loads a CSV file."""
     # Mock the load_csv_safely function to return a valid DataFrame
-    mock_df = pd.DataFrame({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
-    mock_load_csv.return_value = (mock_df, ['col1', 'col2'], 'utf-8')
-    
+    mock_df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+    mock_load_csv.return_value = (mock_df, ["col1", "col2"], "utf-8")
+
     # Create initial state with the CSV file path
-    initial_state = GraphState({
-        'csv_file_path': sample_csv_content,
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": sample_csv_content, "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that the raw_dataframe was added to the state
-    assert 'raw_dataframe' in result_state
-    assert isinstance(result_state['raw_dataframe'], pd.DataFrame)
-    assert 'potential_header' in result_state
-    assert 'encoding_used' in result_state
-    assert len(result_state['raw_dataframe']) == 3  # 3 rows in our mock data
-    assert list(result_state['raw_dataframe'].columns) == ['col1', 'col2']
-    assert result_state['error_messages'] == []
+    assert "raw_dataframe" in result_state
+    assert isinstance(result_state["raw_dataframe"], pd.DataFrame)
+    assert "potential_header" in result_state
+    assert "encoding_used" in result_state
+    assert len(result_state["raw_dataframe"]) == 3  # 3 rows in our mock data
+    assert list(result_state["raw_dataframe"].columns) == ["col1", "col2"]
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_file_not_found(mock_load_csv, runnable_config):
     """Test that the load_csv_node handles file not found errors."""
     # Mock the load_csv_safely function to return None and an error
-    mock_load_csv.return_value = (None, ['File not found: /path/to/nonexistent/file.csv'], None)
-    
+    mock_load_csv.return_value = (
+        None,
+        ["File not found: /path/to/nonexistent/file.csv"],
+        None,
+    )
+
     # Create initial state with a non-existent CSV file path
-    initial_state = GraphState({
-        'csv_file_path': '/path/to/nonexistent/file.csv',
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": "/path/to/nonexistent/file.csv", "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'error_messages' in result_state
-    assert len(result_state['error_messages']) > 0
-    assert 'raw_dataframe' not in result_state
-    assert 'Failed to load CSV file' in result_state['error_messages'][0]
+    assert "error_messages" in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "raw_dataframe" not in result_state
+    assert "Failed to load CSV file" in result_state["error_messages"][0]
+
 
 @pytest.mark.unit
-@patch('Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely')
+@patch("Tabular_to_Neo4j.nodes.input.csv_loader.load_csv_safely")
 def test_load_csv_node_invalid_csv(mock_load_csv, runnable_config):
     """Test that the load_csv_node handles CSV files with parsing issues."""
     # In real-world scenarios, we often encounter CSV files with parsing issues such as:
@@ -67,48 +72,49 @@ def test_load_csv_node_invalid_csv(mock_load_csv, runnable_config):
     # - Quoting issues
     # - Encoding problems
     # This test simulates a CSV file that was loaded but had parsing warnings
-    
+
     # Create a mock DataFrame that represents what we could extract from a problematic CSV
-    mock_df = pd.DataFrame({
-        'id': [1, 2, 3, 4],
-        'name': ['John Doe', 'Jane Smith', 'Error in row', 'Bob Johnson'],
-        'email': ['john@example.com', 'jane@example.com', None, 'bob@example.com']
-    })
-    
+    mock_df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "name": ["John Doe", "Jane Smith", "Error in row", "Bob Johnson"],
+            "email": ["john@example.com", "jane@example.com", None, "bob@example.com"],
+        }
+    )
+
     # Realistic parsing errors that might be encountered
     mock_errors = [
-        'Warning: Line 3 has parsing issues - missing fields',
-        'Warning: Inconsistent quoting detected in file'
+        "Warning: Line 3 has parsing issues - missing fields",
+        "Warning: Inconsistent quoting detected in file",
     ]
-    
+
     # Set the mock return value
-    mock_load_csv.return_value = (mock_df, mock_errors, 'utf-8')
-    
+    mock_load_csv.return_value = (mock_df, mock_errors, "utf-8")
+
     # Create initial state with a CSV file path
     # In a real scenario, this would be a path to an actual file
-    initial_state = GraphState({
-        'csv_file_path': '/path/to/problematic_data.csv',
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {"csv_file_path": "/path/to/problematic_data.csv", "error_messages": []}
+    )
+
     # Call the node
     result_state = load_csv_node(initial_state, runnable_config)
-    
+
     # Check that the raw_dataframe was added to the state despite the parsing issues
-    assert 'raw_dataframe' in result_state
-    assert isinstance(result_state['raw_dataframe'], pd.DataFrame)
-    assert len(result_state['raw_dataframe']) == 4  # 4 rows in our mock data
-    
+    assert "raw_dataframe" in result_state
+    assert isinstance(result_state["raw_dataframe"], pd.DataFrame)
+    assert len(result_state["raw_dataframe"]) == 4  # 4 rows in our mock data
+
     # Check that the warnings are handled appropriately
     # In the actual implementation, parsing warnings are logged but not added to error_messages
     # Instead, the implementation tracks specific issues in dedicated state fields
-    assert 'error_messages' in result_state
-    
+    assert "error_messages" in result_state
+
     # Check that columns with nulls were detected (this is what the implementation actually does)
-    assert 'columns_with_nulls' in result_state
-    assert 'email' in result_state['columns_with_nulls']
-    
+    assert "columns_with_nulls" in result_state
+    assert "email" in result_state["columns_with_nulls"]
+
     # Check that other expected fields are present
-    assert 'potential_header' in result_state
-    assert 'encoding_used' in result_state
-    assert result_state['encoding_used'] == 'utf-8'
+    assert "potential_header" in result_state
+    assert "encoding_used" in result_state
+    assert result_state["encoding_used"] == "utf-8"

--- a/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
+++ b/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
@@ -5,28 +5,34 @@ Tests for the header detection node.
 import pytest
 import pandas as pd
 from unittest.mock import patch
-from Tabular_to_Neo4j.nodes.input.header_detection import detect_header_heuristic_node as detect_header_node
+from Tabular_to_Neo4j.nodes.input.header_detection import (
+    detect_header_heuristic_node as detect_header_node,
+)
 from Tabular_to_Neo4j.app_state import GraphState
+
 
 @pytest.mark.unit
 def test_detect_header_node_with_header(sample_dataframe, runnable_config):
     """Test that the detect_header_node correctly identifies a DataFrame with a header."""
     # Create initial state with a DataFrame that has a header
-    initial_state = GraphState({
-        'raw_dataframe': sample_dataframe,
-        'potential_header': list(sample_dataframe.columns),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": sample_dataframe,
+            "potential_header": list(sample_dataframe.columns),
+            "error_messages": [],
+        }
+    )
+
     # Call the node
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Check that the header was detected
-    assert result_state['has_header_heuristic'] is True
-    assert 'final_header' in result_state
-    assert result_state['final_header'] == list(sample_dataframe.columns)
-    assert 'error_messages' in result_state
-    assert result_state['error_messages'] == []
+    assert result_state["has_header_heuristic"] is True
+    assert "final_header" in result_state
+    assert result_state["final_header"] == list(sample_dataframe.columns)
+    assert "error_messages" in result_state
+    assert result_state["error_messages"] == []
+
 
 @pytest.mark.unit
 def test_detect_header_node_without_header(runnable_config):
@@ -34,52 +40,55 @@ def test_detect_header_node_without_header(runnable_config):
     # In real-world scenarios, we often encounter CSV files with data that could be mistaken for headers
     # This test simulates a dataset where the first row is clearly data, not a header
     # The challenge is that some heuristics might still detect patterns that look like headers
-    df_no_header = pd.DataFrame([
-        # First row is clearly data, not a header
-        ['A123', 'Product X', '12.99', '50', 'In Stock'],
-        ['B456', 'Product Y', '24.99', '30', 'In Stock'],
-        ['C789', 'Product Z', '9.99', '100', 'Low Stock'],
-        ['D012', 'Product W', '19.99', '25', 'Out of Stock'],
-        ['E345', 'Product V', '15.99', '75', 'In Stock']
-    ])
-    
+    df_no_header = pd.DataFrame(
+        [
+            # First row is clearly data, not a header
+            ["A123", "Product X", "12.99", "50", "In Stock"],
+            ["B456", "Product Y", "24.99", "30", "In Stock"],
+            ["C789", "Product Z", "9.99", "100", "Low Stock"],
+            ["D012", "Product W", "19.99", "25", "Out of Stock"],
+            ["E345", "Product V", "15.99", "75", "In Stock"],
+        ]
+    )
+
     # In a real scenario, the CSV loader would provide the first row as potential headers
-    initial_state = GraphState({
-        'raw_dataframe': df_no_header,
-        'potential_header': df_no_header.iloc[0].tolist(),
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "raw_dataframe": df_no_header,
+            "potential_header": df_no_header.iloc[0].tolist(),
+            "error_messages": [],
+        }
+    )
+
     # Call the actual detection function
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Verify that the function executed without errors
-    assert 'has_header_heuristic' in result_state
-    assert 'error_messages' in result_state
-    assert result_state['error_messages'] == []
-    
+    assert "has_header_heuristic" in result_state
+    assert "error_messages" in result_state
+    assert result_state["error_messages"] == []
+
     # Note: We're not asserting the actual value of has_header_heuristic
     # because the current implementation might detect this as a header
     # In a real-world application, this would be followed by manual verification
     # or additional heuristics to improve accuracy
-    
+
     # Document the current behavior for reference
     print(f"Current heuristic detection result: {result_state['has_header_heuristic']}")
     # This output helps us understand the current behavior without failing the test
+
 
 @pytest.mark.unit
 def test_detect_header_node_no_dataframe(runnable_config):
     """Test that the detect_header_node handles missing DataFrame."""
     # Create initial state without a DataFrame
-    initial_state = GraphState({
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict({"error_messages": []})
+
     # Call the node
     result_state = detect_header_node(initial_state, runnable_config)
-    
+
     # Check that an error message was added to the state
-    assert 'has_header_heuristic' not in result_state
-    assert 'detected_header' not in result_state
-    assert len(result_state['error_messages']) > 0
-    assert "Cannot detect header" in result_state['error_messages'][0]
+    assert "has_header_heuristic" not in result_state
+    assert "detected_header" not in result_state
+    assert len(result_state["error_messages"]) > 0
+    assert "Cannot detect header" in result_state["error_messages"][0]

--- a/Tabular_to_Neo4j/tests/test_main.py
+++ b/Tabular_to_Neo4j/tests/test_main.py
@@ -11,44 +11,59 @@ from langchain_core.runnables import RunnableConfig
 from Tabular_to_Neo4j.app_state import GraphState
 from Tabular_to_Neo4j.main import create_graph, run_analysis
 
+
 @pytest.mark.integration
-def test_graph_components_integration(sample_dataframe, runnable_config, mock_llm_response):
+def test_graph_components_integration(
+    sample_dataframe, runnable_config, mock_llm_response
+):
     """Test the integration of graph components directly."""
     # Create the graph
     graph = create_graph()
-    
+
     # Create an initial state with the sample data
     initial_state = {
-        'raw_dataframe': sample_dataframe,
-        'processed_dataframe': sample_dataframe,
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'error_messages': []
+        "raw_dataframe": sample_dataframe,
+        "processed_dataframe": sample_dataframe,
+        "has_header": True,
+        "detected_header": ["id", "name", "age", "email", "city"],
+        "final_header": ["id", "name", "age", "email", "city"],
+        "error_messages": [],
     }
-    
+
     # Test that the graph has the expected nodes
     expected_nodes = [
-        'load_csv', 'detect_header', 'infer_header', 'validate_header',
-        'detect_header_language', 'translate_header', 'apply_header',
-        'analyze_columns', 'semantic_analysis', 'classify_entities_properties',
-        'reconcile_entity_property', 'map_properties_to_entities',
-        'infer_entity_relationships', 'generate_cypher_templates',
-        'synthesize_final_schema'
+        "load_csv",
+        "detect_header",
+        "infer_header",
+        "validate_header",
+        "detect_header_language",
+        "translate_header",
+        "apply_header",
+        "analyze_columns",
+        "semantic_analysis",
+        "classify_entities_properties",
+        "reconcile_entity_property",
+        "map_properties_to_entities",
+        "infer_entity_relationships",
+        "generate_cypher_templates",
+        "synthesize_final_schema",
     ]
-    
+
     for node in expected_nodes:
         assert node in graph.nodes, f"Node {node} not found in graph"
-    
+
     # Test that the graph has edges connecting the nodes
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Verify that the graph is properly connected
     # The first node should be 'load_csv'
-    assert 'load_csv' in graph.nodes, "load_csv node not found"
-    
+    assert "load_csv" in graph.nodes, "load_csv node not found"
+
     # The last node should be 'synthesize_final_schema'
-    assert 'synthesize_final_schema' in graph.nodes, "synthesize_final_schema node not found"
+    assert (
+        "synthesize_final_schema" in graph.nodes
+    ), "synthesize_final_schema node not found"
+
 
 @pytest.mark.integration
 def test_node_execution_mock(sample_dataframe, runnable_config):
@@ -56,141 +71,162 @@ def test_node_execution_mock(sample_dataframe, runnable_config):
     # Import the necessary modules
     from unittest.mock import patch, MagicMock
     from Tabular_to_Neo4j.app_state import GraphState
-    
+
     # Create a mock state with test data
-    initial_state = GraphState({
-        'csv_file_path': '/app/Tabular_to_Neo4j/tests/test_data/sample.csv',
-        'raw_dataframe': sample_dataframe,
-        'processed_dataframe': sample_dataframe,
-        'has_header': True,
-        'detected_header': ['id', 'name', 'age', 'email', 'city'],
-        'final_header': ['id', 'name', 'age', 'email', 'city'],
-        'column_analytics': {
-            'id': {'data_type': 'numeric', 'unique_values': 5},
-            'name': {'data_type': 'string', 'unique_values': 5},
-            'age': {'data_type': 'numeric', 'unique_values': 5},
-            'email': {'data_type': 'string', 'unique_values': 5},
-            'city': {'data_type': 'string', 'unique_values': 5}
-        },
-        'error_messages': []
-    })
-    
+    initial_state = GraphState.from_dict(
+        {
+            "csv_file_path": "/app/Tabular_to_Neo4j/tests/test_data/sample.csv",
+            "raw_dataframe": sample_dataframe,
+            "processed_dataframe": sample_dataframe,
+            "has_header": True,
+            "detected_header": ["id", "name", "age", "email", "city"],
+            "final_header": ["id", "name", "age", "email", "city"],
+            "column_analytics": {
+                "id": {"data_type": "numeric", "unique_values": 5},
+                "name": {"data_type": "string", "unique_values": 5},
+                "age": {"data_type": "numeric", "unique_values": 5},
+                "email": {"data_type": "string", "unique_values": 5},
+                "city": {"data_type": "string", "unique_values": 5},
+            },
+            "error_messages": [],
+        }
+    )
+
     # Create mock LLM response data
     mock_semantic_analysis_result = {
-        'column_semantics': {
-            'id': {'type': 'identifier', 'description': 'Unique identifier'},
-            'name': {'type': 'personal_name', 'description': 'Full name'},
-            'age': {'type': 'numeric_age', 'description': 'Age in years'},
-            'email': {'type': 'email_address', 'description': 'Contact email'},
-            'city': {'type': 'location', 'description': 'City of residence'}
+        "column_semantics": {
+            "id": {"type": "identifier", "description": "Unique identifier"},
+            "name": {"type": "personal_name", "description": "Full name"},
+            "age": {"type": "numeric_age", "description": "Age in years"},
+            "email": {"type": "email_address", "description": "Contact email"},
+            "city": {"type": "location", "description": "City of residence"},
         }
     }
-    
+
     mock_entity_classification_result = {
-        'entities': ['Person'],
-        'properties': ['id', 'name', 'age', 'email', 'city'],
-        'classification': {
-            'id': 'property', 'name': 'property', 'age': 'property',
-            'email': 'property', 'city': 'property'
-        }
-    }
-    
-    mock_entity_reconciliation_result = {
-        'consensus_classification': {
-            'primary_entity': 'Person',
-            'columns': {
-                'id': 'property', 'name': 'property', 'age': 'property',
-                'email': 'property', 'city': 'property'
-            }
-        }
-    }
-    
-    mock_property_mapping_result = {
-        'property_entity_mapping': {
-            'Person': ['id', 'name', 'age', 'email', 'city']
+        "entities": ["Person"],
+        "properties": ["id", "name", "age", "email", "city"],
+        "classification": {
+            "id": "property",
+            "name": "property",
+            "age": "property",
+            "email": "property",
+            "city": "property",
         },
-        'property_types': {
-            'id': 'String', 'name': 'String', 'age': 'Integer',
-            'email': 'String', 'city': 'String'
-        }
     }
-    
-    mock_relationship_inference_result = {
-        'entity_relationships': []
-    }
-    
-    mock_cypher_generation_result = {
-        'cypher_templates': [
-            'CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})'
-        ],
-        'constraints_and_indexes': [
-            'CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'
-        ]
-    }
-    
-    mock_schema_finalization_result = {
-        'final_schema': {
-            'primary_entity_label': 'Person',
-            'columns_classification': {
-                'id': {'entity': 'Person', 'type': 'String', 'is_key': True},
-                'name': {'entity': 'Person', 'type': 'String', 'is_key': False},
-                'age': {'entity': 'Person', 'type': 'Integer', 'is_key': False},
-                'email': {'entity': 'Person', 'type': 'String', 'is_key': False},
-                'city': {'entity': 'Person', 'type': 'String', 'is_key': False}
+
+    mock_entity_reconciliation_result = {
+        "consensus_classification": {
+            "primary_entity": "Person",
+            "columns": {
+                "id": "property",
+                "name": "property",
+                "age": "property",
+                "email": "property",
+                "city": "property",
             },
-            'relationships': [],
-            'cypher_templates': [
-                'CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})'
-            ],
-            'constraints_and_indexes': [
-                'CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE'
-            ]
         }
     }
-    
+
+    mock_property_mapping_result = {
+        "property_entity_mapping": {"Person": ["id", "name", "age", "email", "city"]},
+        "property_types": {
+            "id": "String",
+            "name": "String",
+            "age": "Integer",
+            "email": "String",
+            "city": "String",
+        },
+    }
+
+    mock_relationship_inference_result = {"entity_relationships": []}
+
+    mock_cypher_generation_result = {
+        "cypher_templates": [
+            "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
+        ],
+        "constraints_and_indexes": [
+            "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+        ],
+    }
+
+    mock_schema_finalization_result = {
+        "final_schema": {
+            "primary_entity_label": "Person",
+            "columns_classification": {
+                "id": {"entity": "Person", "type": "String", "is_key": True},
+                "name": {"entity": "Person", "type": "String", "is_key": False},
+                "age": {"entity": "Person", "type": "Integer", "is_key": False},
+                "email": {"entity": "Person", "type": "String", "is_key": False},
+                "city": {"entity": "Person", "type": "String", "is_key": False},
+            },
+            "relationships": [],
+            "cypher_templates": [
+                "CREATE (p:Person {id: $id, name: $name, age: $age, email: $email, city: $city})"
+            ],
+            "constraints_and_indexes": [
+                "CREATE CONSTRAINT person_id_constraint IF NOT EXISTS FOR (p:Person) REQUIRE p.id IS UNIQUE"
+            ],
+        }
+    }
+
     # Test that we can create a graph
     graph = create_graph()
     assert graph is not None
-    
+
     # Test that the graph has the expected nodes
     expected_nodes = [
-        'load_csv', 'detect_header', 'infer_header', 'validate_header',
-        'detect_header_language', 'translate_header', 'apply_header',
-        'analyze_columns', 'semantic_analysis', 'classify_entities_properties',
-        'reconcile_entity_property', 'map_properties_to_entities',
-        'infer_entity_relationships', 'generate_cypher_templates',
-        'synthesize_final_schema'
+        "load_csv",
+        "detect_header",
+        "infer_header",
+        "validate_header",
+        "detect_header_language",
+        "translate_header",
+        "apply_header",
+        "analyze_columns",
+        "semantic_analysis",
+        "classify_entities_properties",
+        "reconcile_entity_property",
+        "map_properties_to_entities",
+        "infer_entity_relationships",
+        "generate_cypher_templates",
+        "synthesize_final_schema",
     ]
-    
+
     for node in expected_nodes:
         assert node in graph.nodes, f"Node {node} not found in graph"
-    
+
     # Test that the graph has edges connecting the nodes
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Instead of testing the actual node execution, let's just test the graph structure
     # This avoids issues with missing prompt templates and other dependencies
-    
+
     # Test the graph connectivity
     # Check that the graph has edges
     assert len(graph.edges) > 0, "Graph has no edges"
-    
+
     # Check that the expected nodes are in the graph
-    assert 'load_csv' in graph.nodes, "load_csv node not found"
-    assert 'detect_header' in graph.nodes, "detect_header node not found"
-    assert 'infer_header' in graph.nodes, "infer_header node not found"
-    assert 'validate_header' in graph.nodes, "validate_header node not found"
-    assert 'semantic_analysis' in graph.nodes, "semantic_analysis node not found"
-    assert 'classify_entities_properties' in graph.nodes, "classify_entities_properties node not found"
-    assert 'synthesize_final_schema' in graph.nodes, "synthesize_final_schema node not found"
-    
+    assert "load_csv" in graph.nodes, "load_csv node not found"
+    assert "detect_header" in graph.nodes, "detect_header node not found"
+    assert "infer_header" in graph.nodes, "infer_header node not found"
+    assert "validate_header" in graph.nodes, "validate_header node not found"
+    assert "semantic_analysis" in graph.nodes, "semantic_analysis node not found"
+    assert (
+        "classify_entities_properties" in graph.nodes
+    ), "classify_entities_properties node not found"
+    assert (
+        "synthesize_final_schema" in graph.nodes
+    ), "synthesize_final_schema node not found"
+
     # Verify the graph has the expected structure
     # Check that nodes are connected in a logical sequence
     # We can't directly check edge connections, but we can verify the graph has edges
     assert graph.edges is not None, "Graph has no edges defined"
     assert len(graph.edges) > 10, "Graph has too few edges"
-    
+
     # The graph structure tests are complete
+
 
 @pytest.mark.unit
 def test_create_graph():
@@ -198,11 +234,10 @@ def test_create_graph():
     # Create the graph
     graph = create_graph()
 
-    
     # Check that the graph has nodes
-    assert hasattr(graph, 'nodes')
+    assert hasattr(graph, "nodes")
     assert len(graph.nodes) > 0
-    
+
     # Check that the graph has edges
-    assert hasattr(graph, 'edges')
+    assert hasattr(graph, "edges")
     assert len(graph.edges) > 0

--- a/Tabular_to_Neo4j/utils/llm_api.py
+++ b/Tabular_to_Neo4j/utils/llm_api.py
@@ -1,0 +1,365 @@
+"""API helpers for interacting with LMStudio models."""
+
+import time
+import random
+import requests
+from contextlib import contextmanager
+from typing import Any, Dict, List
+
+from Tabular_to_Neo4j.utils.logging_config import get_logger
+from Tabular_to_Neo4j.config import DEFAULT_SEED, DEFAULT_TEMPERATURE, LLM_CONFIGS
+
+try:
+    from Tabular_to_Neo4j.config.lmstudio_config import (
+        LMSTUDIO_ENDPOINT,
+        LMSTUDIO_BASE_URL,
+        DEFAULT_MODEL,
+    )
+    from Tabular_to_Neo4j.utils.lmstudio_client import get_lmstudio_client
+
+    LMSTUDIO_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    logger = get_logger(__name__)
+    logger.warning(
+        "LMStudio configuration not found, falling back to default LLM provider"
+    )
+    LMSTUDIO_AVAILABLE = False
+    LMSTUDIO_BASE_URL = "http://localhost:1234/v1"
+
+logger = get_logger(__name__)
+
+_LOADED_MODELS: Dict[str, Dict[str, Any]] = {}
+
+
+def _is_model_loaded(model_name: str) -> bool:
+    if model_name in _LOADED_MODELS:
+        return True
+    try:
+        models = get_lmstudio_models()
+        for model in models:
+            if model.get("id") == model_name and model.get("status") == "loaded":
+                _LOADED_MODELS[model_name] = {
+                    "loaded_at": time.time(),
+                    "loaded_by": "external",
+                }
+                return True
+        return False
+    except Exception as e:
+        logger.warning(f"Error checking if model '{model_name}' is loaded: {e}")
+        return False
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    logger.info(f"Set random seed to {seed} for reproducibility")
+
+
+def get_lmstudio_models() -> List[Dict[str, Any]]:
+    base_url = LMSTUDIO_BASE_URL
+    try:
+        response = requests.get(
+            f"{base_url}/models", headers={"Content-Type": "application/json"}
+        )
+        response.raise_for_status()
+        return response.json().get("data", [])
+    except Exception as e:
+        logger.error(f"Failed to get LMStudio models: {e}")
+        return []
+
+
+def load_model_in_lmstudio(
+    model_name: str, state_name: str | None = None, max_retries: int = 3
+) -> bool:
+    base_url = LMSTUDIO_BASE_URL
+    state_info = f" for state '{state_name}'" if state_name else ""
+
+    if model_name in _LOADED_MODELS and _LOADED_MODELS[model_name].get("loaded", False):
+        logger.info(
+            f"🔄 Model '{model_name}' is already loaded in LMStudio{state_info}"
+        )
+        return True
+
+    logger.info(f"🔍 Searching for model '{model_name}' in LMStudio...")
+    models = get_lmstudio_models()
+    model_id = None
+    for model in models:
+        if model.get("name") == model_name:
+            model_id = model.get("id")
+            break
+    if not model_id:
+        logger.error(f"❌ Model '{model_name}' not found in LMStudio{state_info}")
+        return False
+
+    logger.info(f"⏳ Loading model '{model_name}'{state_info}...")
+    start_time = time.time()
+    for attempt in range(max_retries):
+        try:
+            response = requests.post(
+                f"{base_url}/models/{model_id}/load",
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            _LOADED_MODELS[model_name] = {
+                "id": model_id,
+                "loaded": True,
+                "loaded_at": time.time(),
+                "last_state": state_name,
+            }
+            load_time = time.time() - start_time
+            logger.info(
+                f"✅ Successfully loaded model '{model_name}'{state_info} in {load_time:.2f} seconds"
+            )
+            return True
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                logger.warning(
+                    f"⚠️ Failed to load model '{model_name}'{state_info}: {e}. Retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                logger.error(
+                    f"❌ Failed to load model '{model_name}'{state_info} after {max_retries} attempts: {e}"
+                )
+                return False
+
+
+def unload_model_from_lmstudio(
+    model_name: str, state_name: str | None = None, max_retries: int = 3
+) -> bool:
+    base_url = LMSTUDIO_BASE_URL
+    state_info = f" for state '{state_name}'" if state_name else ""
+
+    if model_name not in _LOADED_MODELS or not _LOADED_MODELS[model_name].get(
+        "loaded", False
+    ):
+        logger.info(f"ℹ️ Model '{model_name}' is not loaded in LMStudio{state_info}")
+        return True
+
+    model_id = _LOADED_MODELS[model_name].get("id")
+    if not model_id:
+        logger.error(f"❌ Model ID for '{model_name}' not found{state_info}")
+        return False
+
+    loaded_at = _LOADED_MODELS[model_name].get("loaded_at", time.time())
+    loaded_duration = time.time() - loaded_at
+    logger.info(f"⏳ Unloading model '{model_name}'{state_info}...")
+
+    for attempt in range(max_retries):
+        try:
+            response = requests.post(
+                f"{base_url}/models/{model_id}/unload",
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            if model_name in _LOADED_MODELS:
+                _LOADED_MODELS[model_name]["loaded"] = False
+                _LOADED_MODELS[model_name]["unloaded_at"] = time.time()
+            logger.info(
+                f"✅ Successfully unloaded model '{model_name}'{state_info} (was loaded for {loaded_duration:.2f} seconds)"
+            )
+            return True
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                logger.warning(
+                    f"⚠️ Failed to unload model '{model_name}'{state_info}: {e}. Retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                logger.error(
+                    f"❌ Failed to unload model '{model_name}'{state_info} after {max_retries} attempts: {e}"
+                )
+                return False
+
+
+def call_lmstudio_api(
+    prompt: str,
+    model_name: str | None = None,
+    temperature: float = 0.7,
+    seed: int = DEFAULT_SEED,
+    state_name: str | None = None,
+    max_retries: int = 3,
+) -> str:
+    from Tabular_to_Neo4j.config import DEFAULT_LMSTUDIO_MODEL
+
+    set_seed(seed)
+    base_url = LMSTUDIO_BASE_URL
+    if not model_name:
+        model_name = DEFAULT_LMSTUDIO_MODEL
+        logger.info(f"No model specified, using default model: {model_name}")
+
+    system_prompt = (
+        "You are a helpful assistant that specializes in data analysis and Neo4j graph modeling. "
+        "Always return valid JSON when asked to do so."
+    )
+    payload = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": temperature,
+        "max_tokens": 2048,
+        "stream": False,
+    }
+    if seed is not None:
+        payload["seed"] = seed
+    headers = {"Content-Type": "application/json"}
+
+    logger.debug(
+        f"Calling LMStudio API with model '{model_name}', temperature {temperature}"
+    )
+    logger.debug(f"Prompt length: {len(prompt)} characters")
+
+    for attempt in range(max_retries):
+        try:
+            logger.debug(f"API call attempt {attempt + 1}/{max_retries}")
+            response = requests.post(
+                f"{base_url}/v1/chat/completions",
+                headers=headers,
+                data=json.dumps(payload),
+                timeout=180,
+            )
+            if response.status_code != 200:
+                logger.error(f"HTTP error {response.status_code}: {response.text}")
+                if attempt < max_retries - 1:
+                    wait_time = 2**attempt
+                    logger.warning(f"Retrying in {wait_time}s...")
+                    time.sleep(wait_time)
+                    continue
+                else:
+                    response.raise_for_status()
+            try:
+                response_data = response.json()
+                logger.debug(
+                    f"Received response from LMStudio API: {str(response_data)[:200]}..."
+                )
+                if "choices" in response_data and len(response_data["choices"]):
+                    if "message" in response_data["choices"][0]:
+                        return response_data["choices"][0]["message"]["content"]
+                    else:
+                        logger.error(f"Unexpected response format: {response_data}")
+                        return str(response_data)
+                else:
+                    logger.error(f"No choices in response: {response_data}")
+                    return str(response_data)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse JSON response: {e}")
+                logger.debug(f"Raw response: {response.text[:500]}...")
+                return response.text
+        except requests.exceptions.ConnectionError:
+            logger.error(
+                f"Connection error: Could not connect to LM Studio at {base_url}"
+            )
+            logger.error(
+                "Please ensure LM Studio is running and accessible at the configured URL"
+            )
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                logger.warning(f"Retrying in {wait_time}s...")
+                time.sleep(wait_time)
+            else:
+                raise ValueError(
+                    f"Could not connect to LM Studio after {max_retries} attempts. Please ensure LM Studio is running at {base_url}"
+                )
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                logger.warning(
+                    f"LMStudio API call failed: {e}. Retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                logger.error(
+                    f"LMStudio API call failed after {max_retries} attempts: {e}"
+                )
+                raise
+    raise RuntimeError(
+        f"Failed to get a valid response from LMStudio after {max_retries} attempts"
+    )
+
+
+@contextmanager
+def load_llm_for_state(state_name: str):
+    config = LLM_CONFIGS.get(state_name, {})
+    provider = config.get("provider", "lmstudio")
+    model_name = config.get("model_name")
+    temperature = config.get("temperature", DEFAULT_TEMPERATURE)
+    seed = config.get("seed", DEFAULT_SEED)
+    auto_load = config.get("auto_load", True)
+    auto_unload = config.get("auto_unload", True)
+    output_format = config.get("output_format", {})
+
+    logger.info(
+        f"Setting up LLM for state '{state_name}' using provider '{provider}' and model '{model_name}'"
+    )
+
+    if auto_load and provider == "lmstudio" and model_name:
+        load_model_in_lmstudio(model_name, state_name)
+
+    def call_llm_func(prompt: str) -> str:
+        nonlocal provider, model_name, temperature, seed, output_format, state_name
+        if output_format:
+            format_type = output_format.get("type", "")
+            format_example = output_format.get("example", "")
+            if format_type and format_example:
+                format_instruction = f"\n\nPlease provide your response in {format_type} format. Example: {format_example}"
+                prompt += format_instruction
+        set_seed(seed)
+        if provider != "lmstudio":
+            logger.warning(
+                f"Provider '{provider}' is not supported. Using LM Studio instead."
+            )
+            provider = "lmstudio"
+        return call_lmstudio_api(prompt, model_name, temperature, seed, state_name)
+
+    try:
+        yield call_llm_func
+    finally:
+        if auto_unload and provider == "lmstudio" and model_name:
+            unload_model_from_lmstudio(model_name, state_name)
+
+
+def get_model_info(state_name: str) -> Dict[str, Any]:
+    config = LLM_CONFIGS.get(state_name, {})
+    provider = config.get("provider", "lmstudio")
+    model_name = config.get("model_name", "Unknown")
+    description = config.get("description", "")
+    output_format = config.get("output_format", {})
+    auto_load = config.get("auto_load", True)
+    auto_unload = config.get("auto_unload", True)
+
+    is_loaded = False
+    loaded_at = None
+    if provider == "lmstudio" and model_name in _LOADED_MODELS:
+        is_loaded = _LOADED_MODELS[model_name].get("loaded", False)
+        loaded_at = _LOADED_MODELS[model_name].get("loaded_at")
+
+    return {
+        "state": state_name,
+        "provider": provider,
+        "model_name": model_name,
+        "description": description,
+        "is_loaded": is_loaded,
+        "loaded_at": loaded_at,
+        "auto_load": auto_load,
+        "auto_unload": auto_unload,
+        "output_format": output_format,
+    }
+
+
+def list_loaded_models() -> List[Dict[str, Any]]:
+    models = []
+    for model_name, info in _LOADED_MODELS.items():
+        models.append(
+            {
+                "name": model_name,
+                "id": info.get("id"),
+                "is_loaded": info.get("loaded", False),
+                "loaded_at": info.get("loaded_at"),
+                "unloaded_at": info.get("unloaded_at", None),
+                "last_state": info.get("last_state"),
+            }
+        )
+    return models

--- a/Tabular_to_Neo4j/utils/llm_manager.py
+++ b/Tabular_to_Neo4j/utils/llm_manager.py
@@ -1,1017 +1,200 @@
-"""
-LLM Manager for loading and unloading GGUF models via LMStudio for different states.
-This module handles per-state LLM configuration, loading, and unloading.
-"""
+"""High-level helpers for invoking language models."""
 
-import os
-import json
-import time
-import random
-import gc
-import logging
-from typing import Dict, Any, Optional, List, Union, Tuple, Callable
-import requests
-from pathlib import Path
+from typing import Dict, Any
+
+from Tabular_to_Neo4j.config import LLM_CONFIGS
 from Tabular_to_Neo4j.utils.logging_config import get_logger
-import re
-from contextlib import contextmanager
+from Tabular_to_Neo4j.utils.llm_api import (
+    LMSTUDIO_AVAILABLE,
+    load_llm_for_state,
+    get_model_info,
+    list_loaded_models,
+)
+from Tabular_to_Neo4j.utils.prompt_utils import (
+    save_prompt_sample,
+    format_prompt,
+)
+from Tabular_to_Neo4j.utils.response_utils import extract_json_from_llm_response
 
-# Configure logging
 logger = get_logger(__name__)
 
-# Import configuration
-from Tabular_to_Neo4j.config import (
-    DEFAULT_SEED,
-    DEFAULT_TEMPERATURE,
-    LLM_CONFIGS
-)
+__all__ = [
+    "format_prompt",
+    "call_llm_with_state",
+    "call_llm_with_json_output",
+    "reset_prompt_sample_directory",
+    "save_prompt_sample",
+    "get_model_info",
+    "list_loaded_models",
+]
 
-# Import LMStudio client
-try:
-    from Tabular_to_Neo4j.config.lmstudio_config import (
-        LMSTUDIO_ENDPOINT,
-        LMSTUDIO_BASE_URL,
-        DEFAULT_MODEL
-    )
-    from Tabular_to_Neo4j.utils.lmstudio_client import get_lmstudio_client
-    LMSTUDIO_AVAILABLE = True
-except ImportError:
-    logger.warning("LMStudio configuration not found, falling back to default LLM provider")
-    LMSTUDIO_AVAILABLE = False
-    # Define a fallback base URL if import fails
-    LMSTUDIO_BASE_URL = "http://localhost:1234/v1"
-
-# Global tracking of loaded models in LMStudio
-# This will store information about which models are currently loaded in LMStudio
-_LOADED_MODELS = {}
-
-def _is_model_loaded(model_name: str) -> bool:
-    """
-    Check if a model is loaded in LMStudio.
-    
-    Args:
-        model_name: Name of the model to check
-        
-    Returns:
-        True if the model is loaded, False otherwise
-    """
-    # First check our local tracking
-    if model_name in _LOADED_MODELS:
-        return True
-        
-    # Then check with LMStudio API
-    try:
-        models = get_lmstudio_models()
-        for model in models:
-            if model.get('id') == model_name and model.get('status') == 'loaded':
-                # Update our local tracking
-                _LOADED_MODELS[model_name] = {
-                    'loaded_at': time.time(),
-                    'loaded_by': 'external'
-                }
-                return True
-        return False
-    except Exception as e:
-        logger.warning(f"Error checking if model '{model_name}' is loaded: {e}")
-        return False
-
-def set_seed(seed: int) -> None:
-    """
-    Set random seed for reproducibility.
-    
-    Args:
-        seed: Seed value to use
-    """
-    random.seed(seed)
-    logger.info(f"Set random seed to {seed} for reproducibility")
-
-def extract_json_from_llm_response(response: str) -> Dict[str, Any]:
-    """
-    Extract JSON from an LLM response, handling various formats including LMStudio responses.
-    
-    Args:
-        response: The raw LLM response text
-        
-    Returns:
-        Parsed JSON as a dictionary
-    """
-    # Handle empty responses
-    if not response or response.strip() == "":
-        logger.warning("Received empty response from LLM")
-        return {"error": "Empty response", "raw_response": ""}
-    
-    # Log the raw response for debugging
-    logger.debug(f"Raw LLM response: {response[:200]}..." if len(response) > 200 else response)
-    
-    # Clean the response - remove any leading/trailing whitespace and newlines
-    cleaned_response = response.strip()
-    
-    # Try to find JSON within triple backticks (common in markdown formatted responses)
-    json_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', cleaned_response)
-    if json_match:
-        json_str = json_match.group(1).strip()
-        logger.debug(f"Found JSON in code block: {json_str[:100]}..." if len(json_str) > 100 else json_str)
-    else:
-        # Try to find JSON within curly braces (find the outermost complete JSON object)
-        # This regex looks for a JSON object that starts with { and ends with }
-        json_match = re.search(r'(\{[\s\S]*?\})', cleaned_response)
-        if json_match:
-            json_str = json_match.group(1).strip()
-            logger.debug(f"Found JSON with braces: {json_str[:100]}..." if len(json_str) > 100 else json_str)
-        else:
-            # Just use the whole response
-            json_str = cleaned_response
-            logger.debug(f"Using whole response as JSON: {json_str[:100]}..." if len(json_str) > 100 else json_str)
-    
-    # If the string doesn't start with {, try to find the first { and parse from there
-    if not json_str.startswith("{"):
-        brace_index = json_str.find("{")
-        if brace_index >= 0:
-            json_str = json_str[brace_index:]
-            logger.debug(f"Trimmed to start at first brace: {json_str[:100]}..." if len(json_str) > 100 else json_str)
-    
-    # If the string doesn't end with }, try to find the last } and parse until there
-    if not json_str.endswith("}"):
-        brace_index = json_str.rfind("}")
-        if brace_index >= 0:
-            json_str = json_str[:brace_index+1]
-            logger.debug(f"Trimmed to end at last brace: {json_str[:100]}..." if len(json_str) > 100 else json_str)
-    
-    # Special handling for LMStudio responses which might have extra text
-    # Sometimes LMStudio adds extra text after the JSON object
-    try:
-        # First try to parse as is
-        return json.loads(json_str)
-    except json.JSONDecodeError:
-        # If that fails, try to extract just the first valid JSON object
-        try:
-            # Find all potential JSON objects in the string
-            potential_jsons = re.findall(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', json_str)
-            if potential_jsons:
-                # Try each potential JSON object until one parses successfully
-                for potential_json in potential_jsons:
-                    try:
-                        return json.loads(potential_json)
-                    except json.JSONDecodeError:
-                        continue
-        except Exception as e:
-            logger.error(f"Error during JSON extraction: {e}")
-    
-    # If we get here, all parsing attempts failed
-    logger.error(f"Failed to parse JSON from LLM response")
-    logger.debug(f"Response was: {response}")
-    logger.debug(f"Attempted to parse: {json_str}")
-    
-    # Fallback: try to create a structured response based on content
-    if "classification" in response.lower() and "column_name" in response.lower():
-        # This is likely an entity classification response
-        # Try to extract the classification (entity or property)
-        if "entity" in response.lower():
-            classification = "entity"
-        elif "property" in response.lower():
-            classification = "property"
-        else:
-            classification = "unknown"
-            
-        # Create a minimal valid response
-        return {
-            "column_name": re.search(r'column_name[":\s]+(\w+)', response, re.IGNORECASE).group(1) if re.search(r'column_name[":\s]+(\w+)', response, re.IGNORECASE) else "unknown",
-            "classification": classification,
-            "confidence": 0.5,  # Default confidence
-            "reasoning": "Extracted from unstructured response"
-        }
-    elif "headers" in response.lower():
-        # This might be a header validation response
-        return {"headers": response}
-    else:
-        # Generic error response
-        return {"error": "Failed to parse JSON", "raw_response": response}
-
-# OpenAI API function removed - using LM Studio exclusively
-
-def get_lmstudio_models() -> List[Dict[str, Any]]:
-    """
-    Get a list of available models in LMStudio.
-    
-    Returns:
-        List of model information dictionaries
-    """
-    base_url = LMSTUDIO_BASE_URL
-    
-    try:
-        response = requests.get(
-            f"{base_url}/models",
-            headers={"Content-Type": "application/json"},
-        )
-        response.raise_for_status()
-        return response.json().get("data", [])
-    except Exception as e:
-        logger.error(f"Failed to get LMStudio models: {e}")
-        return []
-
-def load_model_in_lmstudio(model_name: str, state_name: str = None, max_retries: int = 3) -> bool:
-    """
-    Load a GGUF model in LMStudio.
-    
-    Args:
-        model_name: Name of the model to load
-        state_name: Name of the state requesting the model (for logging)
-        max_retries: Maximum number of retries on failure
-        
-    Returns:
-        True if model was loaded successfully, False otherwise
-    """
-    base_url = LMSTUDIO_BASE_URL
-    state_info = f" for state '{state_name}'" if state_name else ""
-    
-    # Check if model is already loaded
-    if model_name in _LOADED_MODELS and _LOADED_MODELS[model_name].get("loaded", False):
-        logger.info(f"🔄 Model '{model_name}' is already loaded in LMStudio{state_info}")
-        return True
-    
-    logger.info(f"🔍 Searching for model '{model_name}' in LMStudio...")
-    
-    # Get available models
-    models = get_lmstudio_models()
-    model_id = None
-    
-    # Find the model ID by name
-    for model in models:
-        if model.get("name") == model_name:
-            model_id = model.get("id")
-            break
-    
-    if not model_id:
-        logger.error(f"❌ Model '{model_name}' not found in LMStudio{state_info}")
-        return False
-    
-    # Load the model
-    logger.info(f"⏳ Loading model '{model_name}'{state_info}...")
-    start_time = time.time()
-    
-    for attempt in range(max_retries):
-        try:
-            response = requests.post(
-                f"{base_url}/models/{model_id}/load",
-                headers={"Content-Type": "application/json"},
-            )
-            response.raise_for_status()
-            
-            # Track the loaded model
-            _LOADED_MODELS[model_name] = {
-                "id": model_id,
-                "loaded": True,
-                "loaded_at": time.time(),
-                "last_state": state_name
-            }
-            
-            load_time = time.time() - start_time
-            logger.info(f"✅ Successfully loaded model '{model_name}'{state_info} in {load_time:.2f} seconds")
-            return True
-        except Exception as e:
-            if attempt < max_retries - 1:
-                wait_time = 2 ** attempt
-                logger.warning(f"⚠️ Failed to load model '{model_name}'{state_info}: {e}. Retrying in {wait_time}s...")
-                time.sleep(wait_time)
-            else:
-                logger.error(f"❌ Failed to load model '{model_name}'{state_info} after {max_retries} attempts: {e}")
-                return False
-
-def unload_model_from_lmstudio(model_name: str, state_name: str = None, max_retries: int = 3) -> bool:
-    """
-    Unload a GGUF model from LMStudio.
-    
-    Args:
-        model_name: Name of the model to unload
-        state_name: Name of the state that was using the model (for logging)
-        max_retries: Maximum number of retries on failure
-        
-    Returns:
-        True if model was unloaded successfully, False otherwise
-    """
-    base_url = LMSTUDIO_BASE_URL
-    state_info = f" for state '{state_name}'" if state_name else ""
-    
-    # Check if model is loaded
-    if model_name not in _LOADED_MODELS or not _LOADED_MODELS[model_name].get("loaded", False):
-        logger.info(f"ℹ️ Model '{model_name}' is not loaded in LMStudio{state_info}")
-        return True
-    
-    model_id = _LOADED_MODELS[model_name].get("id")
-    if not model_id:
-        logger.error(f"❌ Model ID for '{model_name}' not found{state_info}")
-        return False
-    
-    # Calculate how long the model was loaded
-    loaded_at = _LOADED_MODELS[model_name].get("loaded_at", time.time())
-    loaded_duration = time.time() - loaded_at
-    
-    # Unload the model
-    logger.info(f"⏳ Unloading model '{model_name}'{state_info}...")
-    
-    for attempt in range(max_retries):
-        try:
-            response = requests.post(
-                f"{base_url}/models/{model_id}/unload",
-                headers={"Content-Type": "application/json"},
-            )
-            response.raise_for_status()
-            
-            # Update tracking
-            if model_name in _LOADED_MODELS:
-                _LOADED_MODELS[model_name]["loaded"] = False
-                _LOADED_MODELS[model_name]["unloaded_at"] = time.time()
-            
-            logger.info(f"✅ Successfully unloaded model '{model_name}'{state_info} (was loaded for {loaded_duration:.2f} seconds)")
-            return True
-        except Exception as e:
-            if attempt < max_retries - 1:
-                wait_time = 2 ** attempt
-                logger.warning(f"⚠️ Failed to unload model '{model_name}'{state_info}: {e}. Retrying in {wait_time}s...")
-                time.sleep(wait_time)
-            else:
-                logger.error(f"❌ Failed to unload model '{model_name}'{state_info} after {max_retries} attempts: {e}")
-                return False
-
-def call_lmstudio_api(prompt: str, model_name: str = None, temperature: float = 0.7, seed: int = DEFAULT_SEED, state_name: str = None, max_retries: int = 3) -> str:
-    """
-    Call the LMStudio API with retry logic, specifically configured for Gemma model.
-    
-    Args:
-        prompt: The prompt to send to the API
-        model_name: Name of the model to use (must be loaded in LMStudio)
-        temperature: Temperature setting (0.7 is a good default for Gemma)
-        seed: Seed for reproducibility
-        state_name: Name of the state using the model (for logging)
-        max_retries: Maximum number of retries on failure
-        
-    Returns:
-        The LLM response as a string
-    """
-    import requests
-    import time
-    import json
-    from Tabular_to_Neo4j.config import DEFAULT_LMSTUDIO_MODEL
-    
-    # Set the seed for reproducibility
-    set_seed(seed)
-    
-    # Get the base URL for LMStudio
-    base_url = LMSTUDIO_BASE_URL
-    
-    # If no model name is provided, use the default model
-    if not model_name:
-        model_name = DEFAULT_LMSTUDIO_MODEL
-        logger.info(f"No model specified, using default model: {model_name}")
-    
-    # For Gemma models, we'll use a specific system prompt
-    system_prompt = "You are a helpful assistant that specializes in data analysis and Neo4j graph modeling. Always return valid JSON when asked to do so."
-    
-    # Prepare the request payload for chat completions API
-    payload = {
-        "model": model_name,
-        "messages": [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": prompt}
-        ],
-        "temperature": temperature,
-        "max_tokens": 2048,  # Reasonable limit for responses
-        "stream": False
-    }
-    
-    # Add seed if provided
-    if seed is not None:
-        payload["seed"] = seed
-    
-    headers = {
-        "Content-Type": "application/json"
-    }
-    
-    # Log the request details for debugging
-    logger.debug(f"Calling LMStudio API with model '{model_name}', temperature {temperature}")
-    logger.debug(f"Prompt length: {len(prompt)} characters")
-    
-    # Make the API call with retries
-    for attempt in range(max_retries):
-        try:
-            logger.debug(f"API call attempt {attempt+1}/{max_retries}")
-            
-            response = requests.post(
-                f"{base_url}/v1/chat/completions",  # Use v1 endpoint for compatibility
-                headers=headers,
-                data=json.dumps(payload),
-                timeout=180  # 3-minute timeout for large responses
-            )
-            
-            # Check for HTTP errors
-            if response.status_code != 200:
-                logger.error(f"HTTP error {response.status_code}: {response.text}")
-                if attempt < max_retries - 1:
-                    wait_time = 2 ** attempt  # Exponential backoff
-                    logger.warning(f"Retrying in {wait_time}s...")
-                    time.sleep(wait_time)
-                    continue
-                else:
-                    response.raise_for_status()
-            
-            # Parse the response
-            try:
-                response_data = response.json()
-                logger.debug(f"Received response from LMStudio API: {str(response_data)[:200]}...")
-                
-                # Extract the content from the response
-                if "choices" in response_data and len(response_data["choices"]) > 0:
-                    if "message" in response_data["choices"][0]:
-                        content = response_data["choices"][0]["message"]["content"]
-                        return content
-                    else:
-                        logger.error(f"Unexpected response format: {response_data}")
-                        return str(response_data)  # Return the raw response as a fallback
-                else:
-                    logger.error(f"No choices in response: {response_data}")
-                    return str(response_data)  # Return the raw response as a fallback
-                    
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON response: {e}")
-                logger.debug(f"Raw response: {response.text[:500]}...")
-                return response.text  # Return the raw text as a fallback
-            
-        except requests.exceptions.ConnectionError:
-            logger.error(f"Connection error: Could not connect to LM Studio at {base_url}")
-            logger.error("Please ensure LM Studio is running and accessible at the configured URL")
-            if attempt < max_retries - 1:
-                wait_time = 2 ** attempt  # Exponential backoff
-                logger.warning(f"Retrying in {wait_time}s...")
-                time.sleep(wait_time)
-            else:
-                raise ValueError(f"Could not connect to LM Studio after {max_retries} attempts. Please ensure LM Studio is running at {base_url}")
-                
-        except Exception as e:
-            if attempt < max_retries - 1:
-                wait_time = 2 ** attempt  # Exponential backoff
-                logger.warning(f"LMStudio API call failed: {e}. Retrying in {wait_time}s...")
-                time.sleep(wait_time)
-            else:
-                logger.error(f"LMStudio API call failed after {max_retries} attempts: {e}")
-                raise
-    
-    # If we get here, all retries failed
-    raise RuntimeError(f"Failed to get a valid response from LMStudio after {max_retries} attempts")
-
-@contextmanager
-def load_llm_for_state(state_name: str):
-    """
-    Context manager to load and unload an LLM for a specific state.
-    
-    Args:
-        state_name: The name of the state to load the LLM for
-        
-    Yields:
-        A function to call the loaded LLM
-    """
-    # Get the LLM configuration for this state
-    config = LLM_CONFIGS.get(state_name, {})
-    provider = config.get("provider", DEFAULT_LLM_PROVIDER)
-    model_name = config.get("model_name", None)
-    temperature = config.get("temperature", DEFAULT_TEMPERATURE)
-    seed = config.get("seed", DEFAULT_SEED)
-    auto_load = config.get("auto_load", True)
-    auto_unload = config.get("auto_unload", True)
-    output_format = config.get("output_format", {})
-    
-    logger.info(f"Setting up LLM for state '{state_name}' using provider '{provider}' and model '{model_name}'")
-    
-    # Load the model if auto_load is enabled
-    if auto_load and provider == "lmstudio" and model_name:
-        load_model_in_lmstudio(model_name, state_name)
-    
-    # Define a function to call the LLM
-    def call_llm_func(prompt: str) -> str:
-        nonlocal provider, model_name, temperature, seed, output_format, state_name
-        
-        # Add format instructions to the prompt if specified
-        if output_format:
-            format_type = output_format.get("type", "")
-            format_example = output_format.get("example", "")
-            
-            if format_type and format_example:
-                format_instruction = f"\n\nPlease provide your response in {format_type} format. Example: {format_example}"
-                prompt += format_instruction
-        
-        # Set seed for reproducibility
-        set_seed(seed)
-        
-        # Always use LM Studio as the provider
-        if provider != "lmstudio":
-            logger.warning(f"Provider '{provider}' is not supported. Using LM Studio instead.")
-            provider = "lmstudio"
-            
-        return call_lmstudio_api(prompt, model_name, temperature, seed, state_name)
-    
-    try:
-        # Yield the function to call the LLM
-        yield call_llm_func
-    finally:
-        # Unload the model if auto_unload is enabled
-        if auto_unload and provider == "lmstudio" and model_name:
-            unload_model_from_lmstudio(model_name, state_name)
-
-def load_prompt_template(template_name: str) -> str:
-    """
-    Load a prompt template from the prompts directory.
-    
-    Args:
-        template_name: Name of the template file (e.g., 'infer_header.txt')
-        
-    Returns:
-        The prompt template as a string
-    """
-    base_dir = Path(__file__).parent.parent
-    prompt_path = base_dir / "prompts" / template_name
-    
-    try:
-        with open(prompt_path, 'r', encoding='utf-8') as file:
-            return file.read()
-    except Exception as e:
-        logger.error(f"Error loading prompt template {template_name}: {e}")
-        # Return a basic template if the file doesn't exist
-        return "Please analyze the following data: {data}"
-
-def format_prompt(template_name: str, **kwargs) -> str:
-    """
-    Format a prompt template with the given arguments.
-    
-    Args:
-        template_name: Name of the template file
-        **kwargs: Arguments to format the template with
-        
-    Returns:
-        The formatted prompt as a string
-    """
-    template = load_prompt_template(template_name)
-    
-    # Ensure all kwargs are properly formatted as strings
-    formatted_kwargs = {}
-    for key, value in kwargs.items():
-        if isinstance(value, (int, float)):
-            formatted_kwargs[key] = str(value)
-        elif isinstance(value, list):
-            # Convert lists to a readable string format
-            formatted_kwargs[key] = str(value)
-        elif isinstance(value, dict):
-            # Convert dicts to a readable string format
-            formatted_kwargs[key] = str(value)
-        else:
-            formatted_kwargs[key] = str(value) if value is not None else ""
-    
-    # Always save the template and kwargs for debugging, even if formatting fails
-    save_prompt_sample(template_name, template, formatted_kwargs, is_template=True)
-    
-    try:
-        # Use a simple string replacement approach instead of format
-        formatted_prompt = template
-        for key, value in formatted_kwargs.items():
-            placeholder = '{' + key + '}'
-            formatted_prompt = formatted_prompt.replace(placeholder, value)
-        
-        # Save the formatted prompt to the prompt_samples folder
-        save_prompt_sample(template_name, formatted_prompt, formatted_kwargs)
-        
-        return formatted_prompt
-    except KeyError as e:
-        error_msg = f"Error formatting prompt: missing key {e}. Available keys: {list(formatted_kwargs.keys())}"
-        logger.error(f"Missing key in prompt template {template_name}: {e}")
-        
-        # Save the error message as the formatted prompt for debugging
-        save_prompt_sample(template_name, error_msg, formatted_kwargs, is_error=True)
-        
-        # Return a simplified template with the error message
-        return error_msg
-    except Exception as e:
-        error_msg = f"Error formatting prompt: {str(e)}"
-        logger.error(f"Error formatting prompt template {template_name}: {e}")
-        
-        # Save the error message as the formatted prompt for debugging
-        save_prompt_sample(template_name, error_msg, formatted_kwargs, is_error=True)
-        
-        # Return a simplified template with the error message
-        return error_msg
+from Tabular_to_Neo4j.utils.prompt_utils import (
+    reset_prompt_sample_directory,
+)  # noqa: E402
 
 
 def call_llm_with_state(state_name: str, prompt: str) -> str:
-    """
-    Call the LLM for a specific state.
-    
-    Args:
-        state_name: The name of the state to use the LLM for
-        prompt: The prompt to send to the LLM
-        
-    Returns:
-        The LLM response as a string
-    """
-    # Save the prompt sample before calling the LLM
+    """Call the LLM for a specific pipeline state."""
     try:
-        # Use a generic template name based on the state name
         template_name = f"{state_name}_prompt.txt"
         save_prompt_sample(template_name, prompt, {"state_name": state_name})
-        logger.debug(f"Saved prompt sample for state '{state_name}'")
-    except Exception as e:
-        logger.warning(f"Failed to save prompt sample for state '{state_name}': {str(e)}")
-    
-    # Call the LLM with the loaded model for this state
+        logger.debug("Saved prompt sample for state '%s'", state_name)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning(
+            "Failed to save prompt sample for state '%s': %s", state_name, exc
+        )
+
     with load_llm_for_state(state_name) as llm_func:
         response = llm_func(prompt)
-        
-        # Save the response as well
         try:
-            save_prompt_sample(f"{state_name}_response.txt", response, {"state_name": state_name}, is_template=False)
-            logger.debug(f"Saved response sample for state '{state_name}'")
-        except Exception as e:
-            logger.warning(f"Failed to save response sample for state '{state_name}': {str(e)}")
-        
+            save_prompt_sample(
+                f"{state_name}_response.txt",
+                response,
+                {"state_name": state_name},
+                is_template=False,
+            )
+            logger.debug("Saved response sample for state '%s'", state_name)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning(
+                "Failed to save response sample for state '%s': %s", state_name, exc
+            )
         return response
 
-# Global variable to store the current run's timestamp directory
-_CURRENT_RUN_TIMESTAMP_DIR = None
 
-def reset_prompt_sample_directory():
-    """
-    Reset the prompt sample directory for a new pipeline run.
-    This should be called at the beginning of each pipeline run to ensure
-    all prompt samples from the run are stored in a single directory.
-    """
-    global _CURRENT_RUN_TIMESTAMP_DIR
-    _CURRENT_RUN_TIMESTAMP_DIR = None
-
-def save_prompt_sample(template_name: str, formatted_prompt: str, kwargs: dict, is_template: bool = False, is_error: bool = False) -> None:
-    """
-    Save a formatted prompt sample to the prompt_samples folder.
-    All samples from a single run will be stored in the same directory.
-    Includes numeric identifiers that align with the node order used in the samples directory.
-    
-    Args:
-        template_name: Name of the template file
-        formatted_prompt: The formatted prompt
-        kwargs: The arguments used to format the prompt
-        is_template: Whether this is the original template (not formatted)
-        is_error: Whether this is an error message
-    """
-    import os
-    import json
-    import time
-    from pathlib import Path
-    
-    global _CURRENT_RUN_TIMESTAMP_DIR
-    
-    base_dir = Path(__file__).parent.parent.parent
-    prompt_samples_dir = base_dir / "prompt_samples"
-    
-    # If this is the first prompt in the run, create a new timestamp directory
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
-    if _CURRENT_RUN_TIMESTAMP_DIR is None:
-        # Create a timestamp-based folder name
-        _CURRENT_RUN_TIMESTAMP_DIR = prompt_samples_dir / timestamp
-        
-        # Create the directory
-        os.makedirs(_CURRENT_RUN_TIMESTAMP_DIR, exist_ok=True)
-    
-    # Use the existing timestamp directory for this run
-    timestamp_dir = _CURRENT_RUN_TIMESTAMP_DIR
-    
-    # Define node order mapping that aligns with the one in main.py
-    node_order = {
-        "load_csv": 1,
-        "detect_header": 2,
-        "infer_header": 3,
-        "validate_header": 4,
-        "detect_header_language": 5,
-        "translate_header": 6,
-        "apply_header": 7,
-        "analyze_columns": 8,
-        "classify_entities_properties": 9,
-        "reconcile_entity_property": 10,
-        "map_properties_to_entities": 11,
-        "infer_entity_relationships": 12,
-        "generate_cypher_templates": 13
-    }
-    
-    # Determine the numeric identifier based on the state name
-    state_name = kwargs.get("state_name", "")
-    numeric_id = 0
-    
-    # Extract the base state name from the template name or state_name
-    base_state_name = ""
-    if state_name:
-        base_state_name = state_name
-    else:
-        # Try to extract state name from template_name
-        for node_name in node_order.keys():
-            if node_name in template_name:
-                base_state_name = node_name
-                break
-    
-    # Get the numeric identifier if we found a matching state
-    if base_state_name in node_order:
-        numeric_id = node_order[base_state_name]
-    
-    # Determine the file prefix based on whether this is a template, error, or formatted prompt
-    file_prefix = "template" if is_template else "error" if is_error else "formatted"
-    
-    # For entity classification prompts, include the column name in the filename
-    column_suffix = ""
-    if "classify_entities_properties" in template_name and "column_name" in kwargs:
-        column_suffix = f"_{kwargs['column_name']}"
-    
-    # Save the prompt content with numeric identifier prefix
-    prompt_file = timestamp_dir / f"{numeric_id:02d}_{template_name.replace('.txt', '')}{column_suffix}_{file_prefix}.txt"
-    with open(prompt_file, 'w', encoding='utf-8') as f:
-        f.write(formatted_prompt)
-    
-    # Save the kwargs used to format the prompt with the same numeric identifier
-    kwargs_file = timestamp_dir / f"{numeric_id:02d}_{template_name.replace('.txt', '')}{column_suffix}_{file_prefix}_kwargs.json"
-    with open(kwargs_file, 'w', encoding='utf-8') as f:
-        # Convert any non-serializable objects to strings
-        serializable_kwargs = {}
-        for key, value in kwargs.items():
-            if isinstance(value, (str, int, float, bool, list, dict)) and not isinstance(value, type):
-                serializable_kwargs[key] = value
-            else:
-                serializable_kwargs[key] = str(value)
-        
-        json.dump(serializable_kwargs, f, indent=2)
-        
-    # Save metadata about the prompt sample if it doesn't exist yet
-    metadata_file = timestamp_dir / "metadata.json"
-    if not metadata_file.exists():
-        metadata = {
-            "run_timestamp": timestamp,
-            "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
-            "templates": []
-        }
-        with open(metadata_file, 'w', encoding='utf-8') as f:
-            json.dump(metadata, f, indent=2)
-    
-    # Update the metadata file with this template
-    try:
-        with open(metadata_file, 'r', encoding='utf-8') as f:
-            metadata = json.load(f)
-        
-        # Add this template to the list if not already present
-        template_info = {
-            "template_name": template_name,
-            "is_template": is_template,
-            "is_error": is_error,
-            "file_prefix": file_prefix,
-            "node_type": template_name.replace('.txt', ''),
-        }
-        
-        # For entity classification, include the column name in the metadata
-        if "classify_entities_properties" in template_name and "column_name" in kwargs:
-            template_info["column_name"] = kwargs["column_name"]
-        
-        # Check if this template is already in the list
-        template_exists = False
-        for existing in metadata.get("templates", []):
-            if (existing.get("template_name") == template_name and 
-                existing.get("is_template") == is_template and
-                existing.get("is_error") == is_error and
-                existing.get("column_name", None) == template_info.get("column_name", None)):
-                template_exists = True
-                break
-        
-        if not template_exists:
-            if "templates" not in metadata:
-                metadata["templates"] = []
-            metadata["templates"].append(template_info)
-            
-            with open(metadata_file, 'w', encoding='utf-8') as f:
-                json.dump(metadata, f, indent=2)
-    except Exception as e:
-        # If there's an error updating the metadata, just log it and continue
-        print(f"Error updating metadata: {e}")
-        pass
-
-def call_llm_with_json_output(prompt: str, state_name: str = None) -> Dict[str, Any]:
-    """
-    Call the LLM and parse the response as JSON.
-    
-    Args:
-        prompt: The prompt to send to the LLM
-        state_name: The name of the state to use the LLM for
-        
-    Returns:
-        The parsed JSON response as a dictionary
-    """
-    # If no state is specified, use a default state
+def call_llm_with_json_output(
+    prompt: str, state_name: str | None = None
+) -> Dict[str, Any]:
+    """Call the LLM and parse the response as JSON."""
     if state_name is None:
         state_name = next(iter(LLM_CONFIGS.keys()), None)
-    
-    # Get the LLM configuration for this state
-    state_config = LLM_CONFIGS.get(state_name, {})
-    
-    # Save the original prompt sample
+
     try:
         template_name = f"{state_name}_original_prompt.txt"
         save_prompt_sample(template_name, prompt, {"state_name": state_name})
-        logger.debug(f"Saved original prompt sample for state '{state_name}'")
-    except Exception as e:
-        logger.warning(f"Failed to save original prompt sample for state '{state_name}': {str(e)}")
-    
-    # Check if LMStudio is available and should be used
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning(
+            "Failed to save original prompt sample for state '%s': %s", state_name, exc
+        )
+
     if LMSTUDIO_AVAILABLE:
         try:
-            # Add explicit instructions to return JSON
-            json_prompt = f"{prompt}\n\nPlease provide your response in valid JSON format."
-            
-            # Save the JSON-formatted prompt sample
+            json_prompt = (
+                f"{prompt}\n\nPlease provide your response in valid JSON format."
+            )
             try:
                 template_name = f"{state_name}_json_prompt.txt"
-                save_prompt_sample(template_name, json_prompt, {"state_name": state_name})
-                logger.debug(f"Saved JSON prompt sample for state '{state_name}'")
-            except Exception as e:
-                logger.warning(f"Failed to save JSON prompt sample for state '{state_name}': {str(e)}")
-            
-            # Get LMStudio client
+                save_prompt_sample(
+                    template_name, json_prompt, {"state_name": state_name}
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning(
+                    "Failed to save JSON prompt sample for state '%s': %s",
+                    state_name,
+                    exc,
+                )
+            from Tabular_to_Neo4j.utils.lmstudio_client import get_lmstudio_client
+
             client = get_lmstudio_client()
-            
-            # Call the LMStudio API
-            logger.debug(f"Calling LMStudio API for state '{state_name}'")
+            logger.debug("Calling LMStudio API for state '%s'", state_name)
             response = client.completion(json_prompt)
-            
-            # Extract the text from the response
             response_text = client.extract_completion_text(response)
-            
-            # Save the response
             try:
-                save_prompt_sample(f"{state_name}_json_response.txt", response_text, {"state_name": state_name}, is_template=False)
-                logger.debug(f"Saved JSON response sample for state '{state_name}'")
-            except Exception as e:
-                logger.warning(f"Failed to save JSON response sample for state '{state_name}': {str(e)}")
-            
-            # Try to parse the response as JSON
+                save_prompt_sample(
+                    f"{state_name}_json_response.txt",
+                    response_text,
+                    {"state_name": state_name},
+                    is_template=False,
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning(
+                    "Failed to save JSON response sample for state '%s': %s",
+                    state_name,
+                    exc,
+                )
             json_data = extract_json_from_llm_response(response_text)
-            
             if json_data:
-                logger.debug(f"Successfully parsed JSON response from LMStudio for state '{state_name}'")
                 return json_data
-            else:
-                logger.warning(f"Failed to parse JSON response from LMStudio for state '{state_name}'. Response: {response_text}")
-                
-                # If we couldn't extract JSON, try again with a more explicit prompt
-                retry_prompt = f"{prompt}\n\nYou MUST respond with ONLY valid JSON. No other text. No markdown formatting."
-                
-                # Save the retry prompt sample
-                try:
-                    template_name = f"{state_name}_retry_prompt.txt"
-                    save_prompt_sample(template_name, retry_prompt, {"state_name": state_name})
-                    logger.debug(f"Saved retry prompt sample for state '{state_name}'")
-                except Exception as e:
-                    logger.warning(f"Failed to save retry prompt sample for state '{state_name}': {str(e)}")
-                
-                # Call the LMStudio API again
-                retry_response = client.completion(retry_prompt)
-                retry_text = client.extract_completion_text(retry_response)
-                
-                # Save the retry response
-                try:
-                    save_prompt_sample(f"{state_name}_retry_response.txt", retry_text, {"state_name": state_name}, is_template=False)
-                    logger.debug(f"Saved retry response sample for state '{state_name}'")
-                except Exception as e:
-                    logger.warning(f"Failed to save retry response sample for state '{state_name}': {str(e)}")
-                
-                # Try to parse the retry response
-                retry_json = extract_json_from_llm_response(retry_text)
-                
-                if retry_json:
-                    logger.debug(f"Successfully parsed JSON from retry response from LMStudio for state '{state_name}'")
-                    return retry_json
-                else:
-                    logger.error(f"Failed to parse JSON from retry response from LMStudio for state '{state_name}'. Response: {retry_text}")
-                    # Return an empty dict as a fallback
-                    return {}
-                    
-        except Exception as e:
-            logger.error(f"Error using LMStudio for state '{state_name}': {str(e)}")
+            logger.warning(
+                "Failed to parse JSON response from LMStudio for state '%s'. Response: %s",
+                state_name,
+                response_text,
+            )
+            retry_prompt = f"{prompt}\n\nYou MUST respond with ONLY valid JSON. No other text. No markdown formatting."
+            try:
+                template_name = f"{state_name}_retry_prompt.txt"
+                save_prompt_sample(
+                    template_name, retry_prompt, {"state_name": state_name}
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning(
+                    "Failed to save retry prompt sample for state '%s': %s",
+                    state_name,
+                    exc,
+                )
+            retry_response = client.completion(retry_prompt)
+            retry_text = client.extract_completion_text(retry_response)
+            try:
+                save_prompt_sample(
+                    f"{state_name}_retry_response.txt",
+                    retry_text,
+                    {"state_name": state_name},
+                    is_template=False,
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning(
+                    "Failed to save retry response sample for state '%s': %s",
+                    state_name,
+                    exc,
+                )
+            retry_json = extract_json_from_llm_response(retry_text)
+            if retry_json:
+                return retry_json
+            logger.error(
+                "Failed to parse JSON from retry response from LMStudio for state '%s'. Response: %s",
+                state_name,
+                retry_text,
+            )
+            return {}
+        except Exception as exc:
+            logger.error("Error using LMStudio for state '%s': %s", state_name, exc)
             logger.warning("Falling back to default LLM provider")
-    
-    # If LMStudio is not available or there was an error, use the default implementation
-    # Add explicit instructions to return JSON
+
     json_prompt = f"{prompt}\n\nPlease provide your response in valid JSON format."
-    
-    # Save the JSON-formatted prompt sample
     try:
         template_name = f"{state_name}_json_prompt.txt"
         save_prompt_sample(template_name, json_prompt, {"state_name": state_name})
-        logger.debug(f"Saved JSON prompt sample for state '{state_name}'")
-    except Exception as e:
-        logger.warning(f"Failed to save JSON prompt sample for state '{state_name}': {str(e)}")
-    
-    # Call the LLM
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning(
+            "Failed to save JSON prompt sample for state '%s': %s", state_name, exc
+        )
     response = call_llm_with_state(state_name, json_prompt)
-    
-    # Note: We don't need to save the response here as call_llm_with_state already does this
-    
-    # Try to parse the response as JSON
     try:
-        # First try to extract JSON from the response
         json_data = extract_json_from_llm_response(response)
-        
         if json_data:
-            logger.debug(f"Successfully parsed JSON response for state '{state_name}'")
             return json_data
-        else:
-            logger.warning(f"Failed to parse JSON response for state '{state_name}'. Response: {response}")
-            
-            # If we couldn't extract JSON, try again with a more explicit prompt
-            retry_prompt = f"{prompt}\n\nYou MUST respond with ONLY valid JSON. No other text. No markdown formatting."
-            
-            # Save the retry prompt sample
-            try:
-                template_name = f"{state_name}_retry_prompt.txt"
-                save_prompt_sample(template_name, retry_prompt, {"state_name": state_name})
-                logger.debug(f"Saved retry prompt sample for state '{state_name}'")
-            except Exception as e:
-                logger.warning(f"Failed to save retry prompt sample for state '{state_name}': {str(e)}")
-            
-            # Call the LLM again
-            retry_response = call_llm_with_state(state_name, retry_prompt)
-            
-            # Note: We don't need to save the retry response here as call_llm_with_state already does this
-            
-            # Try to parse the retry response
-            retry_json = extract_json_from_llm_response(retry_response)
-            
-            if retry_json:
-                logger.debug(f"Successfully parsed JSON from retry response for state '{state_name}'")
-                return retry_json
-            else:
-                logger.error(f"Failed to parse JSON from retry response for state '{state_name}'. Response: {retry_response}")
-                # Return an empty dict as a fallback
-                return {}
-    
-    except Exception as e:
-        logger.error(f"Error parsing JSON response for state '{state_name}': {str(e)}")
-        # Return a dictionary with the error and raw response
-        return {
-            "error": str(e),
-            "raw_response": response
-        }
-
-def get_model_info(state_name: str) -> Dict[str, Any]:
-    """
-    Get information about the model configured for a specific state.
-    
-    Args:
-        state_name: The name of the state
-        
-    Returns:
-        Dictionary with model information
-    """
-    config = LLM_CONFIGS.get(state_name, {})
-    provider = config.get("provider", DEFAULT_LLM_PROVIDER)
-    model_name = config.get("model_name", "Unknown")
-    description = config.get("description", "")
-    output_format = config.get("output_format", {})
-    auto_load = config.get("auto_load", True)
-    auto_unload = config.get("auto_unload", True)
-    
-    # Check if the model is currently loaded
-    is_loaded = False
-    loaded_at = None
-    if provider == "lmstudio" and model_name in _LOADED_MODELS:
-        is_loaded = _LOADED_MODELS[model_name].get("loaded", False)
-        loaded_at = _LOADED_MODELS[model_name].get("loaded_at")
-    
-    return {
-        "state": state_name,
-        "provider": provider,
-        "model_name": model_name,
-        "description": description,
-        "is_loaded": is_loaded,
-        "loaded_at": loaded_at,
-        "auto_load": auto_load,
-        "auto_unload": auto_unload,
-        "output_format": output_format
-    }
-
-
-def list_loaded_models() -> List[Dict[str, Any]]:
-    """
-    List all models that are currently loaded or have been loaded.
-    
-    Returns:
-        List of dictionaries with model information
-    """
-    models = []
-    
-    for model_name, info in _LOADED_MODELS.items():
-        models.append({
-            "name": model_name,
-            "id": info.get("id"),
-            "is_loaded": info.get("loaded", False),
-            "loaded_at": info.get("loaded_at"),
-            "unloaded_at": info.get("unloaded_at", None),
-            "last_state": info.get("last_state")
-        })
-    
-    return models
+        logger.warning(
+            "Failed to parse JSON response for state '%s'. Response: %s",
+            state_name,
+            response,
+        )
+        retry_prompt = f"{prompt}\n\nYou MUST respond with ONLY valid JSON. No other text. No markdown formatting."
+        try:
+            template_name = f"{state_name}_retry_prompt.txt"
+            save_prompt_sample(template_name, retry_prompt, {"state_name": state_name})
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning(
+                "Failed to save retry prompt sample for state '%s': %s", state_name, exc
+            )
+        retry_response = call_llm_with_state(state_name, retry_prompt)
+        retry_json = extract_json_from_llm_response(retry_response)
+        if retry_json:
+            return retry_json
+        logger.error(
+            "Failed to parse JSON from retry response for state '%s'. Response: %s",
+            state_name,
+            retry_response,
+        )
+        return {}
+    except Exception as exc:
+        logger.error("Error parsing JSON response for state '%s': %s", state_name, exc)
+        return {"error": str(exc), "raw_response": response}

--- a/Tabular_to_Neo4j/utils/prompt_utils.py
+++ b/Tabular_to_Neo4j/utils/prompt_utils.py
@@ -1,0 +1,183 @@
+"""Utilities for loading and formatting prompts."""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Dict
+
+from Tabular_to_Neo4j.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_CURRENT_RUN_TIMESTAMP_DIR = None
+
+
+def reset_prompt_sample_directory() -> None:
+    """Reset the prompt sample directory for a new pipeline run."""
+    global _CURRENT_RUN_TIMESTAMP_DIR
+    _CURRENT_RUN_TIMESTAMP_DIR = None
+
+
+def load_prompt_template(template_name: str) -> str:
+    """Load a prompt template from the prompts directory."""
+    base_dir = Path(__file__).parent.parent
+    prompt_path = base_dir / "prompts" / template_name
+    try:
+        with open(prompt_path, "r", encoding="utf-8") as file:
+            return file.read()
+    except Exception as e:
+        logger.error(f"Error loading prompt template {template_name}: {e}")
+        return "Please analyze the following data: {data}"
+
+
+def save_prompt_sample(
+    template_name: str,
+    formatted_prompt: str,
+    kwargs: Dict,
+    *,
+    is_template: bool = False,
+    is_error: bool = False,
+) -> None:
+    """Save a formatted prompt sample to the prompt_samples folder."""
+    global _CURRENT_RUN_TIMESTAMP_DIR
+
+    base_dir = Path(__file__).parent.parent.parent
+    prompt_samples_dir = base_dir / "prompt_samples"
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    if _CURRENT_RUN_TIMESTAMP_DIR is None:
+        _CURRENT_RUN_TIMESTAMP_DIR = prompt_samples_dir / timestamp
+        os.makedirs(_CURRENT_RUN_TIMESTAMP_DIR, exist_ok=True)
+
+    timestamp_dir = _CURRENT_RUN_TIMESTAMP_DIR
+
+    node_order = {
+        "load_csv": 1,
+        "detect_header": 2,
+        "infer_header": 3,
+        "validate_header": 4,
+        "detect_header_language": 5,
+        "translate_header": 6,
+        "apply_header": 7,
+        "analyze_columns": 8,
+        "classify_entities_properties": 9,
+        "reconcile_entity_property": 10,
+        "map_properties_to_entities": 11,
+        "infer_entity_relationships": 12,
+        "generate_cypher_templates": 13,
+    }
+
+    state_name = kwargs.get("state_name", "")
+    numeric_id = 0
+    base_state_name = state_name
+    if not base_state_name:
+        for node_name in node_order.keys():
+            if node_name in template_name:
+                base_state_name = node_name
+                break
+    if base_state_name in node_order:
+        numeric_id = node_order[base_state_name]
+
+    file_prefix = "template" if is_template else "error" if is_error else "formatted"
+    column_suffix = ""
+    if "classify_entities_properties" in template_name and "column_name" in kwargs:
+        column_suffix = f"_{kwargs['column_name']}"
+
+    prompt_file = (
+        timestamp_dir
+        / f"{numeric_id:02d}_{template_name.replace('.txt', '')}{column_suffix}_{file_prefix}.txt"
+    )
+    with open(prompt_file, "w", encoding="utf-8") as f:
+        f.write(formatted_prompt)
+
+    kwargs_file = (
+        timestamp_dir
+        / f"{numeric_id:02d}_{template_name.replace('.txt', '')}{column_suffix}_{file_prefix}_kwargs.json"
+    )
+    with open(kwargs_file, "w", encoding="utf-8") as f:
+        serializable_kwargs = {}
+        for key, value in kwargs.items():
+            if isinstance(
+                value, (str, int, float, bool, list, dict)
+            ) and not isinstance(value, type):
+                serializable_kwargs[key] = value
+            else:
+                serializable_kwargs[key] = str(value)
+        json.dump(serializable_kwargs, f, indent=2)
+
+    metadata_file = timestamp_dir / "metadata.json"
+    if not metadata_file.exists():
+        metadata = {
+            "run_timestamp": timestamp,
+            "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "templates": [],
+        }
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+
+    try:
+        with open(metadata_file, "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+        template_info = {
+            "template_name": template_name,
+            "is_template": is_template,
+            "is_error": is_error,
+            "file_prefix": file_prefix,
+            "node_type": template_name.replace(".txt", ""),
+        }
+        if "classify_entities_properties" in template_name and "column_name" in kwargs:
+            template_info["column_name"] = kwargs["column_name"]
+        template_exists = False
+        for existing in metadata.get("templates", []):
+            if (
+                existing.get("template_name") == template_name
+                and existing.get("is_template") == is_template
+                and existing.get("is_error") == is_error
+                and existing.get("column_name", None)
+                == template_info.get("column_name", None)
+            ):
+                template_exists = True
+                break
+        if not template_exists:
+            metadata.setdefault("templates", []).append(template_info)
+            with open(metadata_file, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, indent=2)
+    except Exception as e:
+        print(f"Error updating metadata: {e}")
+
+
+def format_prompt(template_name: str, **kwargs) -> str:
+    """Format a prompt template with the given arguments."""
+    template = load_prompt_template(template_name)
+
+    formatted_kwargs: Dict[str, str] = {}
+    for key, value in kwargs.items():
+        if isinstance(value, (int, float)):
+            formatted_kwargs[key] = str(value)
+        elif isinstance(value, list):
+            formatted_kwargs[key] = str(value)
+        elif isinstance(value, dict):
+            formatted_kwargs[key] = str(value)
+        else:
+            formatted_kwargs[key] = str(value) if value is not None else ""
+
+    save_prompt_sample(template_name, template, formatted_kwargs, is_template=True)
+
+    try:
+        formatted_prompt = template
+        for key, value in formatted_kwargs.items():
+            placeholder = "{" + key + "}"
+            formatted_prompt = formatted_prompt.replace(placeholder, value)
+        save_prompt_sample(template_name, formatted_prompt, formatted_kwargs)
+        return formatted_prompt
+    except KeyError as e:
+        error_msg = f"Error formatting prompt: missing key {e}. Available keys: {list(formatted_kwargs.keys())}"
+        logger.error(f"Missing key in prompt template {template_name}: {e}")
+        save_prompt_sample(template_name, error_msg, formatted_kwargs, is_error=True)
+        return error_msg
+    except Exception as e:
+        error_msg = f"Error formatting prompt: {str(e)}"
+        logger.error(f"Error formatting prompt template {template_name}: {e}")
+        save_prompt_sample(template_name, error_msg, formatted_kwargs, is_error=True)
+        return error_msg

--- a/Tabular_to_Neo4j/utils/response_utils.py
+++ b/Tabular_to_Neo4j/utils/response_utils.py
@@ -1,0 +1,106 @@
+"""Utility functions for parsing LLM responses."""
+
+import json
+import re
+from typing import Dict, Any
+
+from Tabular_to_Neo4j.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def extract_json_from_llm_response(response: str) -> Dict[str, Any]:
+    """Extract JSON data from a raw LLM response."""
+    if not response or response.strip() == "":
+        logger.warning("Received empty response from LLM")
+        return {"error": "Empty response", "raw_response": ""}
+
+    logger.debug(
+        f"Raw LLM response: {response[:200]}..." if len(response) > 200 else response
+    )
+    cleaned_response = response.strip()
+
+    json_match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", cleaned_response)
+    if json_match:
+        json_str = json_match.group(1).strip()
+        logger.debug(
+            f"Found JSON in code block: {json_str[:100]}..."
+            if len(json_str) > 100
+            else json_str
+        )
+    else:
+        json_match = re.search(r"(\{[\s\S]*?\})", cleaned_response)
+        if json_match:
+            json_str = json_match.group(1).strip()
+            logger.debug(
+                f"Found JSON with braces: {json_str[:100]}..."
+                if len(json_str) > 100
+                else json_str
+            )
+        else:
+            json_str = cleaned_response
+            logger.debug(
+                f"Using whole response as JSON: {json_str[:100]}..."
+                if len(json_str) > 100
+                else json_str
+            )
+
+    if not json_str.startswith("{"):
+        brace_index = json_str.find("{")
+        if brace_index >= 0:
+            json_str = json_str[brace_index:]
+            logger.debug(
+                f"Trimmed to start at first brace: {json_str[:100]}..."
+                if len(json_str) > 100
+                else json_str
+            )
+
+    if not json_str.endswith("}"):
+        brace_index = json_str.rfind("}")
+        if brace_index >= 0:
+            json_str = json_str[: brace_index + 1]
+            logger.debug(
+                f"Trimmed to end at last brace: {json_str[:100]}..."
+                if len(json_str) > 100
+                else json_str
+            )
+
+    try:
+        return json.loads(json_str)
+    except json.JSONDecodeError:
+        try:
+            potential_jsons = re.findall(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", json_str)
+            if potential_jsons:
+                for potential_json in potential_jsons:
+                    try:
+                        return json.loads(potential_json)
+                    except json.JSONDecodeError:
+                        continue
+        except Exception as e:
+            logger.error(f"Error during JSON extraction: {e}")
+
+    logger.error("Failed to parse JSON from LLM response")
+    logger.debug(f"Response was: {response}")
+    logger.debug(f"Attempted to parse: {json_str}")
+
+    if "classification" in response.lower() and "column_name" in response.lower():
+        if "entity" in response.lower():
+            classification = "entity"
+        elif "property" in response.lower():
+            classification = "property"
+        else:
+            classification = "unknown"
+        return {
+            "column_name": (
+                re.search(r'column_name[":\s]+(\w+)', response, re.IGNORECASE).group(1)
+                if re.search(r'column_name[":\s]+(\w+)', response, re.IGNORECASE)
+                else "unknown"
+            ),
+            "classification": classification,
+            "confidence": 0.5,
+            "reasoning": "Extracted from unstructured response",
+        }
+    elif "headers" in response.lower():
+        return {"headers": response}
+    else:
+        return {"error": "Failed to parse JSON", "raw_response": response}


### PR DESCRIPTION
## Summary
- replace TypedDict `GraphState` with dataclass that behaves like a mapping
- adjust tests to instantiate state with `GraphState.from_dict`
- modularize the LLM utilities by splitting `llm_manager` into API, prompt, and response helpers

## Testing
- `black Tabular_to_Neo4j/utils/llm_manager.py Tabular_to_Neo4j/utils/prompt_utils.py Tabular_to_Neo4j/utils/response_utils.py Tabular_to_Neo4j/utils/llm_api.py Tabular_to_Neo4j/nodes/entity_inference/property_mapping.py Tabular_to_Neo4j/nodes/entity_inference/relationship_inference.py Tabular_to_Neo4j/nodes/entity_inference/entity_classification.py Tabular_to_Neo4j/nodes/entity_inference/entity_reconciliation.py Tabular_to_Neo4j/nodes/header_processing/header_inference.py Tabular_to_Neo4j/nodes/header_processing/header_translation.py Tabular_to_Neo4j/nodes/header_processing/header_validation.py Tabular_to_Neo4j/nodes/db_schema/cypher_generation.py Tabular_to_Neo4j/main.py`
- `pytest -q` *(fails: missing pandas/langchain_core)*

------
https://chatgpt.com/codex/tasks/task_e_68475cd453bc832fb622727ef8e24cc1