### PR TITLE
Allow LMStudio configuration via environment variables

### DIFF
--- a/README_LMSTUDIO.md
+++ b/README_LMSTUDIO.md
@@ -16,6 +16,20 @@ This guide explains how to use the Tabular to Neo4j converter with LMStudio inte
 4. Click "Start Server"
 5. Make sure the server is running on port 1234 (default)
 
+## Environment Variables
+
+The application reads the LMStudio host, port and default model from the
+environment. You can override the defaults by setting the following variables:
+
+```
+LMSTUDIO_HOST=<host IP or name>
+LMSTUDIO_PORT=<port number>
+LMSTUDIO_DEFAULT_MODEL=<model id>
+```
+
+These variables can be set in your shell, in a `.env` file, or passed via Docker
+`-e` options.
+
 ## Running with Docker
 
 The repository includes Docker configuration to connect to LMStudio running on your host machine. You can use either Docker Compose directly or the provided Makefile targets.

--- a/Tabular_to_Neo4j/config.py
+++ b/Tabular_to_Neo4j/config.py
@@ -10,7 +10,11 @@ DEFAULT_SEED = 42  # Default seed for reproducibility
 DEFAULT_TEMPERATURE = 0.0  # Default temperature (0.0 for deterministic results)
 
 # LMStudio settings for GGUF models
-LMSTUDIO_BASE_URL = "http://localhost:1234/v1"  # Default LMStudio local server
+import os
+
+LMSTUDIO_BASE_URL = os.environ.get(
+    "LMSTUDIO_BASE_URL", "http://localhost:1234/v1"
+)
 
 # Per-State LLM Configuration with GGUF models through LMStudio
 # Each state has its own model and output format specification
@@ -162,7 +166,9 @@ LLM_CONFIGS = {
 }
 
 # Default model to use if not specified in LLM_CONFIGS
-DEFAULT_LMSTUDIO_MODEL = "Mistral-7B-Instruct-v0.2-GGUF"  # Default model for LM Studio
+DEFAULT_LMSTUDIO_MODEL = os.environ.get(
+    "LMSTUDIO_DEFAULT_MODEL", "Mistral-7B-Instruct-v0.2-GGUF"
+)  # Default model for LM Studio
 
 # CSV Processing Settings
 MAX_SAMPLE_ROWS = 5  # Maximum number of rows to include in LLM prompts

--- a/Tabular_to_Neo4j/config/lmstudio_config.py
+++ b/Tabular_to_Neo4j/config/lmstudio_config.py
@@ -1,18 +1,25 @@
+"""Configuration for LMStudio integration.
+
+Values can be overridden using environment variables so the application can be
+easily configured in different deployment environments.
 """
-Configuration for LMStudio integration.
-"""
+
+import os
+
 
 # LMStudio server configuration
-LMSTUDIO_HOST = "127.0.0.1"  # Special Docker DNS name that resolves to the host machine
-LMSTUDIO_PORT = 1234
-LMSTUDIO_BASE_URL = f"http://{LMSTUDIO_HOST}:{LMSTUDIO_PORT}"
-LMSTUDIO_API_VERSION = "v1"
-LMSTUDIO_ENDPOINT = f"{LMSTUDIO_BASE_URL}/{LMSTUDIO_API_VERSION}"
+LMSTUDIO_HOST = os.environ.get("LMSTUDIO_HOST", "127.0.0.1")
+LMSTUDIO_PORT = int(os.environ.get("LMSTUDIO_PORT", 1234))
+LMSTUDIO_BASE_URL = os.environ.get(
+    "LMSTUDIO_BASE_URL", f"http://{LMSTUDIO_HOST}:{LMSTUDIO_PORT}"
+)
+LMSTUDIO_API_VERSION = os.environ.get("LMSTUDIO_API_VERSION", "v1")
+LMSTUDIO_ENDPOINT = f"{LMSTUDIO_BASE_URL.rstrip('/')}/{LMSTUDIO_API_VERSION}"
 
 # Default model to use
-DEFAULT_MODEL = "local-model"  # This will be replaced with the actual model name from LMStudio
+DEFAULT_MODEL = os.environ.get("LMSTUDIO_DEFAULT_MODEL", "local-model")
 
 # API parameters
-DEFAULT_TEMPERATURE = 0.0
-DEFAULT_MAX_TOKENS = 1024
-DEFAULT_TOP_P = 0.95
+DEFAULT_TEMPERATURE = float(os.environ.get("LMSTUDIO_DEFAULT_TEMPERATURE", 0.0))
+DEFAULT_MAX_TOKENS = int(os.environ.get("LMSTUDIO_DEFAULT_MAX_TOKENS", 1024))
+DEFAULT_TOP_P = float(os.environ.get("LMSTUDIO_DEFAULT_TOP_P", 0.95))

--- a/Tabular_to_Neo4j/run_with_lmstudio.py
+++ b/Tabular_to_Neo4j/run_with_lmstudio.py
@@ -15,7 +15,6 @@ if str(repo_root.parent) not in sys.path:
     sys.path.insert(0, str(repo_root.parent))
 
 from Tabular_to_Neo4j.utils.check_lmstudio import check_lmstudio_connection
-from Tabular_to_Neo4j.main import run_analysis
 
 def main():
     """
@@ -36,6 +35,10 @@ def main():
                       help='Directory to save node outputs to (default: samples)')
     
     args = parser.parse_args()
+
+    # Set environment variables for LMStudio before importing the main module
+    os.environ["LMSTUDIO_HOST"] = args.lmstudio_host
+    os.environ["LMSTUDIO_PORT"] = str(args.lmstudio_port)
     
     # Check if CSV file exists
     csv_path = Path(args.csv_file)
@@ -58,26 +61,8 @@ def main():
         print("   If running in Docker, make sure the container has access to the host network.")
         sys.exit(1)
     
-    # Update the LMStudio configuration
-    config_dir = os.path.join(repo_root, "config")
-    config_file = os.path.join(config_dir, "lmstudio_config.py")
-    
-    if os.path.exists(config_file):
-        with open(config_file, "r") as f:
-            config_content = f.read()
-        
-        # Update the host and port
-        config_content = config_content.replace(
-            f'LMSTUDIO_HOST = "host.docker.internal"',
-            f'LMSTUDIO_HOST = "{args.lmstudio_host}"'
-        )
-        config_content = config_content.replace(
-            f'LMSTUDIO_PORT = 1234',
-            f'LMSTUDIO_PORT = {args.lmstudio_port}'
-        )
-        
-        with open(config_file, "w") as f:
-            f.write(config_content)
+    # Import run_analysis only after environment variables are set
+    from Tabular_to_Neo4j.main import run_analysis
     
     # Run the analysis
     print(f"Running analysis on {args.csv_file} with LMStudio integration...")


### PR DESCRIPTION
## Summary
- read LMStudio host, port and model from environment variables
- load run_with_lmstudio after setting env vars
- document environment variables in LMStudio guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core' and 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848181c3474832fbd588d1c8c0b1baa