### PR TITLE
Improve env var handling with dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for Tabular_to_Neo4j
+
+# API keys
+LLM_API_KEY=
+
+# LLM provider selection
+LLM_PROVIDER=lmstudio
+
+# LMStudio connection parameters
+LMSTUDIO_HOST=127.0.0.1
+LMSTUDIO_PORT=1234
+LMSTUDIO_BASE_URL=http://127.0.0.1:1234/v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Set environment variable for LM Studio connection
-ENV LMSTUDIO_HOST=host.docker.internal
-ENV LMSTUDIO_PORT=1234
+# Default LMStudio connection parameters can be provided via environment variables
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -207,7 +207,16 @@ The system exclusively uses LM Studio for all LLM interactions:
 
 ## Configuration
 
-You can customize the system behavior in `config.py`:
+Environment variables are loaded from a `.env` file at the repository root. A
+sample file `.env.example` is provided. Copy it to `.env` and adjust the values
+for your environment:
+
+```bash
+cp .env.example .env
+# edit .env with your preferred settings
+```
+
+You can also customize the system behavior in `config.py`:
 
 ```python
 # LLM Configuration

--- a/README_LMSTUDIO.md
+++ b/README_LMSTUDIO.md
@@ -8,6 +8,13 @@ This guide explains how to use the Tabular to Neo4j converter with LMStudio inte
 2. Docker and Docker Compose installed (if running in Docker)
 3. Python 3.8+ (if running locally)
 
+Before running the application, copy the provided `.env.example` file to `.env`
+and adjust the values if needed:
+
+```bash
+cp .env.example .env
+```
+
 ## Setting Up LMStudio
 
 1. Open LMStudio on your local machine

--- a/Tabular_to_Neo4j/config.py
+++ b/Tabular_to_Neo4j/config.py
@@ -1,16 +1,20 @@
-"""
-Configuration settings for the Tabular to Neo4j converter.
-"""
+"""Configuration settings for the Tabular to Neo4j converter."""
+
+import os
+from dotenv import load_dotenv, find_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv(find_dotenv())
 
 # General LLM Configuration
-LLM_API_KEY = ""  # Not used with LM Studio but kept for compatibility
+LLM_API_KEY = os.getenv("LLM_API_KEY", "")  # Not used with LM Studio but kept for compatibility
 TARGET_HEADER_LANGUAGE = "English"  # Target language for headers
-DEFAULT_LLM_PROVIDER = "lmstudio"  # Using LMStudio exclusively for all LLM interactions
+DEFAULT_LLM_PROVIDER = os.getenv("LLM_PROVIDER", "lmstudio")
 DEFAULT_SEED = 42  # Default seed for reproducibility
 DEFAULT_TEMPERATURE = 0.0  # Default temperature (0.0 for deterministic results)
 
 # LMStudio settings for GGUF models
-LMSTUDIO_BASE_URL = "http://localhost:1234/v1"  # Default LMStudio local server
+LMSTUDIO_BASE_URL = os.getenv("LMSTUDIO_BASE_URL", "http://localhost:1234/v1")
 
 # Per-State LLM Configuration with GGUF models through LMStudio
 # Each state has its own model and output format specification

--- a/Tabular_to_Neo4j/config/lmstudio_config.py
+++ b/Tabular_to_Neo4j/config/lmstudio_config.py
@@ -1,18 +1,22 @@
-"""
-Configuration for LMStudio integration.
-"""
+"""Configuration for LMStudio integration."""
+
+import os
+from dotenv import load_dotenv, find_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv(find_dotenv())
 
 # LMStudio server configuration
-LMSTUDIO_HOST = "127.0.0.1"  # Special Docker DNS name that resolves to the host machine
-LMSTUDIO_PORT = 1234
-LMSTUDIO_BASE_URL = f"http://{LMSTUDIO_HOST}:{LMSTUDIO_PORT}"
-LMSTUDIO_API_VERSION = "v1"
-LMSTUDIO_ENDPOINT = f"{LMSTUDIO_BASE_URL}/{LMSTUDIO_API_VERSION}"
+LMSTUDIO_HOST = os.getenv("LMSTUDIO_HOST", "127.0.0.1")
+LMSTUDIO_PORT = int(os.getenv("LMSTUDIO_PORT", 1234))
+LMSTUDIO_BASE_URL = os.getenv("LMSTUDIO_BASE_URL", f"http://{LMSTUDIO_HOST}:{LMSTUDIO_PORT}")
+LMSTUDIO_API_VERSION = os.getenv("LMSTUDIO_API_VERSION", "v1")
+LMSTUDIO_ENDPOINT = os.getenv("LMSTUDIO_ENDPOINT", f"{LMSTUDIO_BASE_URL}/{LMSTUDIO_API_VERSION}")
 
 # Default model to use
-DEFAULT_MODEL = "local-model"  # This will be replaced with the actual model name from LMStudio
+DEFAULT_MODEL = os.getenv("LMSTUDIO_DEFAULT_MODEL", "local-model")
 
 # API parameters
-DEFAULT_TEMPERATURE = 0.0
-DEFAULT_MAX_TOKENS = 1024
-DEFAULT_TOP_P = 0.95
+DEFAULT_TEMPERATURE = float(os.getenv("LMSTUDIO_DEFAULT_TEMPERATURE", 0.0))
+DEFAULT_MAX_TOKENS = int(os.getenv("LMSTUDIO_DEFAULT_MAX_TOKENS", 1024))
+DEFAULT_TOP_P = float(os.getenv("LMSTUDIO_DEFAULT_TOP_P", 0.95))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/app
-    environment:
-      - LMSTUDIO_HOST=127.0.0.1
-      - LMSTUDIO_PORT=1234
+    env_file:
+      - .env
     network_mode: "host"
 
 networks:

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -15,14 +15,20 @@ pip install -e .
 
 # Create a .env file for configuration
 if [ ! -f .env ]; then
-    echo "Creating .env file for configuration..."
-    cat > .env << EOF
+    echo "Creating .env file from template..."
+    if [ -f .env.example ]; then
+        cp .env.example .env
+    else
+        cat > .env << EOF
 # LLM API Configuration
-LLM_API_KEY=""  # Set your API key here
-LLM_PROVIDER="lmstudio"  # Options: "openai", "ollama", "anthropic", "lmstudio", "huggingface"
-LMSTUDIO_BASE_URL="http://localhost:1234/v1"  # Default LMStudio local server
+LLM_API_KEY=""
+LLM_PROVIDER="lmstudio"
+LMSTUDIO_HOST="127.0.0.1"
+LMSTUDIO_PORT="1234"
+LMSTUDIO_BASE_URL="http://127.0.0.1:1234/v1"
 EOF
-    echo ".env file created. Please edit it to add your API keys."
+    fi
+    echo ".env file created. Please edit it to add your API keys and settings."
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in `config.py` and `lmstudio_config.py`
- supply `.env.example` template and update `setup_env.sh` to use it
- reference `.env` usage in documentation
- use `.env` with docker-compose
- cleanup Dockerfile defaults

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_68481cf15108832fb71cb912af30d380