### PR TITLE
Centralize logging across modules

### DIFF
--- a/Tabular_to_Neo4j/main.py
+++ b/Tabular_to_Neo4j/main.py
@@ -293,31 +293,28 @@ def run_analysis(
     if verbose:
         logger.info("Displaying analysis results")
 
-        # Print any errors
+        # Log any errors
         if final_state.get("error_messages"):
-            print("\nErrors/Warnings encountered during analysis:")
+            logger.info("\nErrors/Warnings encountered during analysis:")
             for error in final_state.get("error_messages", []):
-                print(f"  - {error}")
+                logger.info("  - %s", error)
 
-        # Print the generated Cypher templates
+        # Log the generated Cypher templates
         if final_state.get("cypher_query_templates"):
             templates = final_state["cypher_query_templates"]
-            print("\nGenerated Cypher Templates:")
+            logger.info("\nGenerated Cypher Templates:")
 
-            print("\nENTITY CREATION QUERIES:")
+            logger.info("\nENTITY CREATION QUERIES:")
             for i, query in enumerate(templates.get("entity_creation_queries", [])):
-                print(f"\nQuery {i+1}:")
-                print(query.get("query", ""))
+                logger.info("\nQuery %s:\n%s", i + 1, query.get("query", ""))
 
-            print("\nRELATIONSHIP QUERIES:")
+            logger.info("\nRELATIONSHIP QUERIES:")
             for i, query in enumerate(templates.get("relationship_queries", [])):
-                print(f"\nQuery {i+1}:")
-                print(query.get("query", ""))
+                logger.info("\nQuery %s:\n%s", i + 1, query.get("query", ""))
 
-            print("\nEXAMPLE QUERIES:")
+            logger.info("\nEXAMPLE QUERIES:")
             for i, query in enumerate(templates.get("example_queries", [])):
-                print(f"\nQuery {i+1}:")
-                print(query.get("query", ""))
+                logger.info("\nQuery %s:\n%s", i + 1, query.get("query", ""))
 
     return final_state
 
@@ -356,7 +353,7 @@ def main():
             args.output_dir,
         )
     except Exception as e:
-        print(f"Error: {str(e)}")
+        logger.error("Error: %s", e)
         sys.exit(1)
 
 

--- a/Tabular_to_Neo4j/test_sample.py
+++ b/Tabular_to_Neo4j/test_sample.py
@@ -5,7 +5,7 @@ Test script to demonstrate the Tabular to Neo4j converter with a sample CSV file
 
 import os
 import sys
-from Tabular_to_Neo4j.utils.logging_config import get_logger
+from Tabular_to_Neo4j.utils.logging_config import get_logger, setup_logging
 from pathlib import Path
 
 # Add the parent directory to the path to import the module
@@ -17,12 +17,7 @@ from Tabular_to_Neo4j.main import run_analysis
 
 # Configure logging
 logger = get_logger(__name__)
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
-)
+setup_logging()
 
 
 def main():

--- a/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
+++ b/Tabular_to_Neo4j/tests/nodes/input/test_header_detection.py
@@ -9,6 +9,10 @@ from Tabular_to_Neo4j.nodes.input.header_detection import (
     detect_header_heuristic_node as detect_header_node,
 )
 from Tabular_to_Neo4j.app_state import GraphState
+from Tabular_to_Neo4j.utils.logging_config import get_logger, setup_logging
+
+logger = get_logger(__name__)
+setup_logging()
 
 
 @pytest.mark.unit
@@ -74,7 +78,10 @@ def test_detect_header_node_without_header(runnable_config):
     # or additional heuristics to improve accuracy
 
     # Document the current behavior for reference
-    print(f"Current heuristic detection result: {result_state['has_header_heuristic']}")
+    logger.info(
+        "Current heuristic detection result: %s",
+        result_state["has_header_heuristic"],
+    )
     # This output helps us understand the current behavior without failing the test
 
 

--- a/Tabular_to_Neo4j/update_logging.py
+++ b/Tabular_to_Neo4j/update_logging.py
@@ -9,6 +9,10 @@ import re
 import glob
 from pathlib import Path
 
+from Tabular_to_Neo4j.utils.logging_config import get_logger, setup_logging
+
+logger = get_logger(__name__)
+
 def update_logging_imports(file_path):
     """Update logging imports in a file to use the centralized logging configuration."""
     with open(file_path, 'r') as f:
@@ -16,7 +20,7 @@ def update_logging_imports(file_path):
     
     # Check if file already uses our logging config
     if 'from Tabular_to_Neo4j.utils.logging_config import get_logger' in content:
-        print(f"File already updated: {file_path}")
+        logger.info("File already updated: %s", file_path)
         return False
     
     # Replace standard logging import with our centralized config
@@ -47,12 +51,14 @@ def update_logging_imports(file_path):
         with open(file_path, 'w') as f:
             f.write(content)
         
-        print(f"Updated logging in: {file_path}")
+        logger.info("Updated logging in: %s", file_path)
         return True
     
     return False
 
 def main():
+    setup_logging()
+
     """Update logging configuration in all Python files in the project."""
     # Get the project root directory
     project_root = Path(__file__).parent
@@ -70,7 +76,11 @@ def main():
         if update_logging_imports(file_path):
             updated_count += 1
     
-    print(f"\nUpdated logging in {updated_count} files out of {len(python_files)} total Python files.")
+    logger.info(
+        "\nUpdated logging in %s files out of %s total Python files.",
+        updated_count,
+        len(python_files),
+    )
 
 if __name__ == "__main__":
     main()

--- a/Tabular_to_Neo4j/utils/prompt_utils.py
+++ b/Tabular_to_Neo4j/utils/prompt_utils.py
@@ -144,7 +144,7 @@ def save_prompt_sample(
             with open(metadata_file, "w", encoding="utf-8") as f:
                 json.dump(metadata, f, indent=2)
     except Exception as e:
-        print(f"Error updating metadata: {e}")
+        logger.error("Error updating metadata: %s", e)
 
 
 def format_prompt(template_name: str, **kwargs) -> str:


### PR DESCRIPTION
## Summary
- update scripts and tests to use centralized logger
- replace print statements with logger usage
- initialize logging consistently with `setup_logging`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for langchain_core and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6848393b4e08832f8ee66f24fa9cddc4