### PR TITLE
Add package docstrings

### DIFF
--- a/Tabular_to_Neo4j/__init__.py
+++ b/Tabular_to_Neo4j/__init__.py
@@ -1,1 +1,3 @@
 
+"""Top-level package for the Tabular_to_Neo4j project."""
+

--- a/Tabular_to_Neo4j/nodes/__init__.py
+++ b/Tabular_to_Neo4j/nodes/__init__.py
@@ -1,1 +1,2 @@
+"""Graph processing nodes for Tabular_to_Neo4j."""
 

--- a/Tabular_to_Neo4j/tests/__init__.py
+++ b/Tabular_to_Neo4j/tests/__init__.py
@@ -1,1 +1,2 @@
+"""Unit tests for the Tabular_to_Neo4j project."""
 

--- a/Tabular_to_Neo4j/utils/__init__.py
+++ b/Tabular_to_Neo4j/utils/__init__.py
@@ -1,1 +1,2 @@
+"""Utility modules for the Tabular_to_Neo4j project."""
 


### PR DESCRIPTION
## Summary
- ensure packages have basic module docstrings for context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and langchain_core)*

------
https://chatgpt.com/codex/tasks/task_e_68483de85448832fa1583b60d46738c9